### PR TITLE
chore(autonomy): CI edited trigger, PR-format starter prompt, dep-gate via traceability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: ci
 on:
   pull_request:
     branches: [develop, main]
+    # Include `edited` so changes to PR title/body re-trigger format checks
+    # (check-pr-title, check-pr-description) without needing an empty commit.
+    types: [opened, synchronize, reopened, edited]
   push:
     branches: [develop, main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
     branches: [develop, main]
     # Include `edited` so changes to PR title/body re-trigger format checks
     # (check-pr-title, check-pr-description) without needing an empty commit.
-    # Heavy jobs (typecheck, lint, unit, integration, e2e-smoke, etc.) are
-    # gated below so they skip on `edited` — only the two format checks re-run.
+    # Heavy jobs re-run too — tolerable cost for correctness (skipped required
+    # checks block merge under branch protection).
     types: [opened, synchronize, reopened, edited]
   push:
     branches: [develop, main]
@@ -19,7 +19,6 @@ jobs:
   typecheck:
     name: typecheck
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -36,7 +35,6 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -53,7 +51,6 @@ jobs:
   unit:
     name: unit
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -72,7 +69,6 @@ jobs:
   integration:
     name: integration
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -91,7 +87,6 @@ jobs:
   e2e-smoke:
     name: e2e-smoke
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -179,7 +174,6 @@ jobs:
   doc-consistency:
     name: doc-consistency
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -196,7 +190,6 @@ jobs:
   schema-drift:
     name: schema-drift
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [develop, main]
     # Include `edited` so changes to PR title/body re-trigger format checks
     # (check-pr-title, check-pr-description) without needing an empty commit.
+    # Heavy jobs (typecheck, lint, unit, integration, e2e-smoke, etc.) are
+    # gated below so they skip on `edited` — only the two format checks re-run.
     types: [opened, synchronize, reopened, edited]
   push:
     branches: [develop, main]
@@ -17,6 +19,7 @@ jobs:
   typecheck:
     name: typecheck
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -33,6 +36,7 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -49,6 +53,7 @@ jobs:
   unit:
     name: unit
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -67,6 +72,7 @@ jobs:
   integration:
     name: integration
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -85,6 +91,7 @@ jobs:
   e2e-smoke:
     name: e2e-smoke
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -172,6 +179,7 @@ jobs:
   doc-consistency:
     name: doc-consistency
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -188,6 +196,7 @@ jobs:
   schema-drift:
     name: schema-drift
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ apps/api/drizzle/meta/_snapshot.json
 # Claude Code agent runtime state (per-session, not repo content)
 .claude/scheduled_tasks.lock
 .claude/scheduled_tasks/
+
+# Per-machine Claude Code settings (not for team sharing)
+.claude/settings.local.json

--- a/docs/overnight-autonomous-run.md
+++ b/docs/overnight-autonomous-run.md
@@ -46,7 +46,7 @@ The launcher generates a prompt at `/tmp/cc-starter-<ws-id>.md`. It instructs th
 3. **Project hooks** (`scripts/claude-hooks/pre-tool-use-bash.sh`): additional project-specific filtering.
 4. **Pre-commit lefthook**: blocks `as any`, `@ts-ignore`, `console.*` in api/src, schema changes without migrations, secrets via gitleaks.
 5. **Branch protection**: main and develop refuse force-push, require PR reviews.
-6. **GitHub Actions CI** (`.github/workflows/ci.yml`): typecheck, lint, unit, integration, schema-drift, doc-consistency, build, Playwright E2E (Chromium + WebKit).
+6. **GitHub Actions CI** (`.github/workflows/ci.yml`): typecheck, lint, unit, integration, schema-drift, doc-consistency, and an `e2e-smoke` Playwright job that runs every `e2e/specs/AC-*-*.spec.ts` against Chromium. (A build job and broader WebKit matrix are planned but not yet in the workflow — don't assume them as safety nets.)
 7. **CodeRabbit**: reviews each PR push. Blocking feedback must be addressed before merge.
 8. **Cascade coordinator safety** (see §5): conservative merge criteria, max 4 merges/hour, kill switch, never touches main.
 

--- a/docs/overnight-autonomous-run.md
+++ b/docs/overnight-autonomous-run.md
@@ -1,0 +1,169 @@
+# Overnight autonomous run — runbook
+
+This document describes how to run online-chat-server workstreams autonomously while you sleep. The system has multiple Claude Code sessions each working on one workstream in its own git worktree, plus a cascade coordinator that auto-merges green PRs and spawns dependents.
+
+## Pre-flight checklist (10 min)
+
+1. Land any in-flight Phase 0 / feature work to develop.
+2. Update develop: `git checkout develop && git pull`.
+3. Confirm lefthook is installed: `lefthook install`.
+4. Confirm CI is green on develop (GitHub Actions `ci.yml`).
+5. Confirm `.claude/settings.local.json` exists in the project (gitignored — won't be in repo). If missing, pull it from a teammate or recreate per the template in §6 below.
+6. Confirm the cascade coordinator plist is loaded: `launchctl list | grep cascade-coordinator`.
+7. Decide which workstreams to run tonight. See `docs/workstreams/proposed-workstreams.md` and `docs/workstreams/workstream-dependency-and-interface-map.md`. Only spawn workstreams whose dependencies are already on develop.
+
+## Launching
+
+```bash
+./scripts/spawn-workstream-windows.sh WS-01 WS-02
+```
+
+- Each workstream gets a new worktree at `../online-chat-server-worktrees/<ws-id-lower>/`.
+- Each worktree runs on a fresh branch `feature/<WS-ID>-autorun-<YYYYMMDD>` off `origin/develop`.
+- Each opens a new Terminal window with `claude` CLI already running the starter prompt.
+- Each spawn is logged to `~/.claude/cc-optimizer/spawn-log.jsonl`.
+
+### Launcher flags
+
+- `--dry-run`: print intended actions, no side effects. Run this first on any new setup.
+- `--force`: bypass the dependency gate (only for testing).
+
+### Per-workstream starter prompt
+
+The launcher generates a prompt at `/tmp/cc-starter-<ws-id>.md`. It instructs the session to:
+
+- Read CLAUDE.md §6, the guardrails, traceability.md AC rows, and the workstream's paragraph.
+- Stick strictly to files that belong to its workstream.
+- Commit per AC, push, update traceability.md.
+- Open a draft PR labeled `autorun` after the first commit.
+- Enter a mandatory polish phase after the last AC: address CodeRabbit comments, mark ready, post `<!-- autorun: ready-for-merge -->` marker.
+- Stop cleanly if uncertain or near `maxTurns: 80`.
+
+## Safety nets active
+
+1. **Project `.claude/settings.local.json`**: `bypassPermissions` + `maxTurns: 80` + deny list blocking destructive operations, pushes to main/develop, `--no-verify`, sudo, etc.
+2. **Global hooks** (`~/.claude/hooks/block-rm-rf.sh`, `block-push-main.sh`): catch hook-level attempts.
+3. **Project hooks** (`scripts/claude-hooks/pre-tool-use-bash.sh`): additional project-specific filtering.
+4. **Pre-commit lefthook**: blocks `as any`, `@ts-ignore`, `console.*` in api/src, schema changes without migrations, secrets via gitleaks.
+5. **Branch protection**: main and develop refuse force-push, require PR reviews.
+6. **GitHub Actions CI** (`.github/workflows/ci.yml`): typecheck, lint, unit, integration, schema-drift, doc-consistency, build, Playwright E2E (Chromium + WebKit).
+7. **CodeRabbit**: reviews each PR push. Blocking feedback must be addressed before merge.
+8. **Cascade coordinator safety** (see §5): conservative merge criteria, max 4 merges/hour, kill switch, never touches main.
+
+Four fences on the outer side (deny list, global hooks, project hooks, pre-commit), two on the inner side (CI, CodeRabbit).
+
+## Deviation audit — risks and preemption
+
+| # | Risk | Preemption |
+|---|------|------------|
+| 1 | Scope creep across workstreams | Starter prompt scopes allowed files. Morning digest flags cross-workstream file edits. |
+| 2 | Contract breakage (TypeBox schema edit breaks consumer) | `pnpm schema-drift` pre-commit + CI job. Digest flags schemas touched by multiple worktrees. |
+| 3 | Dependency violation (WS-04 starts before WS-03 lands) | Launcher dependency gate. `--force` only for testing. |
+| 4 | Runaway fix-loop | `maxTurns: 80`. Stop hook notification fires when cap hit. |
+| 5 | Silent "done" without real completion | Starter prompt requires updating traceability.md per AC. Digest cross-checks. |
+| 6 | Secrets committed | gitleaks pre-commit. |
+| 7 | Port collision on `docker compose` | Starter prompt: `docker compose ps` check before starting. |
+| 8 | Hallucinated APIs/paths | `tsc` in pre-commit + CI typecheck. |
+| 9 | Cross-worktree contention on develop | No auto-merge from session (cascade coordinator is the only auto-merger, with strict criteria). |
+| 10 | Context compaction mid-workstream | Fresh per-workstream sessions, terse starter prompts, `/compact` at AC boundaries. |
+
+## Context preservation practices
+
+- **One workstream per session**. Fresh context per worktree.
+- **Starter prompt is terse.** Only AC rows + workstream paragraph, not the whole project.
+- **Explore subagent for broad searches.** Keeps research out of main context.
+- **Commit per AC.** State lives in git. The session reloads git when it needs it.
+- **Interim notes to `docs/workstream-notes/<ws-id>-progress.md`.** Designated scratch.
+- **`/compact` at AC boundaries.** Explicit cleanup.
+- **`maxTurns: 80`.** Hard cap on runaways.
+
+## Morning triage flow
+
+1. Run the digest:
+   ```bash
+   ~/.claude/bin/daily-digest.sh
+   ```
+   Opens a report at `~/.claude/cc-optimizer/digests/YYYY-MM-DD.md` in VSCode.
+2. For each workstream:
+   - Read its section of the digest (commits, files touched, AC claims, typecheck/lint status).
+   - Open the draft PR (link in digest).
+   - Read CodeRabbit comments. Address any the session missed.
+   - Check CI status.
+   - If clean: `gh pr ready <num>` (session may have already done this), review the diff yourself, merge.
+3. After merging a workstream, clean up its worktree:
+   ```bash
+   git worktree remove ../online-chat-server-worktrees/<ws-id-lower>
+   ```
+4. If any workstream flagged blocked: open `docs/workstream-notes/<ws-id>-blockers.md`, resolve the question, decide whether to restart or hand-finish.
+5. Kick off the next phase (if not already cascaded).
+
+## Troubleshooting
+
+### Session stuck / hung
+- Check spawn log: `tail ~/.claude/cc-optimizer/spawn-log.jsonl`. Find the PID.
+- Check Stop hook notification — did the session stop cleanly?
+- Kill: `kill <pid>`. Or kill all autorun sessions at once: see kill switch below.
+
+### Session hit `maxTurns`
+- The Stop hook fires with `Task finished` notification. In the digest, "maxTurns hit" flag appears.
+- Either restart the session (`cd <worktree> && claude < /tmp/cc-starter-<ws-id>.md`) to continue, or take over manually.
+
+### Cascade coordinator misbehaving
+- Kill switch: `touch ~/.claude/cc-optimizer/cascade-disabled`. Coordinator exits immediately on next run.
+- Full unload: `launchctl unload ~/Library/LaunchAgents/com.elisey.cascade-coordinator.plist`.
+- Inspect log: `tail -50 ~/.claude/cc-optimizer/cascade.log`.
+- To re-enable after fixing: `rm ~/.claude/cc-optimizer/cascade-disabled` (and re-load if you unloaded).
+
+### Kill everything (last-resort panic button)
+```bash
+# Stop cascade
+touch ~/.claude/cc-optimizer/cascade-disabled
+launchctl unload ~/Library/LaunchAgents/com.elisey.cascade-coordinator.plist
+
+# Kill all autorun CC sessions
+pkill -f "claude.*cc-starter" || true
+rm -f /tmp/cc-starter-*.md
+```
+This leaves worktrees in place for you to review. Remove them manually after.
+
+### Worktree has uncommitted changes when you try to remove
+```bash
+git worktree remove --force <path>
+```
+
+### PR didn't auto-merge even though it looks ready
+- Check the cascade criteria in `~/.claude/bin/cascade-coordinator.sh` §7.1.
+- Common misses: PR still draft (session didn't un-draft), no `<!-- autorun: ready-for-merge -->` comment, CI check not SUCCESS (maybe SKIPPED is fine, check logic), last commit too recent (wait for 15-min idle threshold).
+- Inspect `cascade.log`: look for the PR number and the skip reason.
+
+## Cascade coordinator overview (see `~/.claude/bin/cascade-coordinator.sh` for implementation)
+
+- Runs every hour between 22:00 and 08:00 via launchd plist `com.elisey.cascade-coordinator`.
+- For each PR labeled `autorun`, evaluates ALL criteria:
+  - CI all-green
+  - Not draft
+  - CodeRabbit not CHANGES_REQUESTED
+  - Has `<!-- autorun: ready-for-merge -->` comment
+  - Last commit ≥ 15 minutes old
+  - No `blocked`/`needs-human-review`/`cascade-hold` label
+- If all pass: `gh pr merge --squash --delete-branch`, then spawn newly-unblocked dependents.
+- Max 4 auto-merges per hour.
+- All decisions logged to `~/.claude/cc-optimizer/cascade.log`.
+
+## settings.local.json template
+
+If lost, recreate from `.claude/settings.local.json` in the dotfiles repo or per §1 of the plan at `~/.claude/plans/`. Key fields:
+
+```json
+{
+  "permissionMode": "bypassPermissions",
+  "maxTurns": 80,
+  "permissions": {
+    "allow": ["Edit", "Write", "MultiEdit"],
+    "deny": ["Bash(rm -rf *)", "Bash(git push origin develop*)", "Bash(sudo *)", "...many more..."],
+    "additionalDirectories": ["/tmp", "/Users/elisey/Downloads/online-chat-server", "/Users/elisey/Downloads/online-chat-server-worktrees"]
+  }
+}
+```
+
+This file is **gitignored** so each machine manages its own copy.

--- a/scripts/spawn-workstream-windows.sh
+++ b/scripts/spawn-workstream-windows.sh
@@ -100,7 +100,7 @@ Work rhythm:
     gh pr create --draft --base develop --head feature/${ws_id}-autorun-${DATE_TAG} --label autorun --title "${ws_id} autorun" --body "Autonomous overnight run for ${ws_id}. Draft \u2014 human review required before merge."
   The \`autorun\` label is what the cascade coordinator watches for. Each push re-triggers CodeRabbit + CI.
 - After each commit, update docs/traceability.md with the completion note for that AC row.
-- If you are not 100% certain about an AC, interpretation, API contract, or product decision: STOP. Do not guess. Write the question to docs/workstream-notes/${ws_lower}-blockers.md and end your turn with a clear "BLOCKED: <why>" message.
+- If you are not 100% certain about an AC, interpretation, API contract, or product decision: STOP. Do not guess. Write the question to docs/workstream-notes/${ws_lower}-blockers.md, commit+push that note, open the draft PR with title prefix "${ws_id} autorun (BLOCKED — <short reason>)", then add the \`blocked\` label: \`gh pr edit <num> --add-label blocked\`. The Stop hook recognizes that label and lets you exit cleanly. The cascade coordinator also skips blocked-labeled PRs. End your turn with a clear "BLOCKED: <why>" message.
 - maxTurns=80. Near the cap, commit in-progress work cleanly and STOP rather than leaving a change mid-way.
 
 End-of-workstream polish phase (MANDATORY before ending the session):

--- a/scripts/spawn-workstream-windows.sh
+++ b/scripts/spawn-workstream-windows.sh
@@ -126,12 +126,16 @@ Work rhythm:
 
 End-of-workstream polish phase (MANDATORY before ending the session):
 1. After your last AC is delivered and pushed, wait ~5 minutes so CodeRabbit has time to post its review.
-2. Fetch review state: \`gh pr view <num> --json reviews,comments\`.
-3. For each actionable CodeRabbit comment: either fix (commit + push) or reply with a clear rationale. Mark threads resolved via \`gh api ...\` or the GitHub API.
-4. Repeat the fetch-address-push loop until CodeRabbit's latest review is APPROVED or every comment has an explicit resolution.
+2. Fetch review state: \`gh pr view <num> --json reviews\`. Fetch threads: \`gh api graphql -f query='{repository(owner:\"electronicostrich\",name:\"online-chat-server\"){pullRequest(number:<num>){reviewThreads(first:100){nodes{id isResolved isOutdated path line comments(first:1){nodes{url body}}}}}}}'\`
+3. Classify every unresolved, non-outdated thread by severity:
+   - **Major / Potential-issue** = must-fix before merge: address (commit + push) OR reply with explicit rationale AND resolve the thread via \`mutation { resolveReviewThread(input: { threadId: "<id>" }) { thread { id } } }\`.
+   - **Minor / Nitpick / Trivial** = may defer: EITHER resolve inline OR file a GitHub issue labeled \`deferred-stage-2\` with title \`CR follow-up (${ws_id} PR #<num>): <file> — <heading>\` and body pointing to the comment URL. Then resolve the thread.
+4. Repeat the fetch-address-push loop until CodeRabbit's latest review is APPROVED or every thread is either resolved or filed-as-issue.
 5. Mark the PR ready (remove draft): \`gh pr ready <num>\`.
 6. Post the cascade-ready marker as a PR comment: \`gh pr comment <num> --body "<!-- autorun: ready-for-merge -->"\`.
 7. Only THEN end your session cleanly. Do not merge the PR yourself \u2014 cascade coordinator or a human handles merge.
+
+NOTE: develop branch protection no longer requires all conversations resolved to merge (we flipped it off intentionally), so a few unresolved nit-threads won't block auto-merge. But your polish phase MUST still file every unresolved thread as either a tracked issue or an in-thread resolution so nothing gets lost.
 
 Context preservation:
 - Use the Explore subagent for broad codebase searches. Don't dump raw search results into your main context.

--- a/scripts/spawn-workstream-windows.sh
+++ b/scripts/spawn-workstream-windows.sh
@@ -194,10 +194,27 @@ spawn_one() {
     echo "SKIP: worktree already exists at $worktree_path (remove first with: git worktree remove $worktree_path)"
     return 1
   fi
-  run "cd '$PROJECT_DIR' && git worktree add -b '$branch' '$worktree_path' origin/develop"
+  if (cd "$PROJECT_DIR" && git rev-parse --verify "$branch" >/dev/null 2>&1); then
+    echo "SKIP: branch $branch already exists (delete first with: git branch -D $branch)"
+    return 1
+  fi
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "DRY: cd '$PROJECT_DIR' && git worktree add -b '$branch' '$worktree_path' origin/develop"
+  else
+    if ! (cd "$PROJECT_DIR" && git worktree add -b "$branch" "$worktree_path" origin/develop); then
+      echo "FAIL: git worktree add for $ws_id failed — aborting this spawn (no Terminal will open)"
+      return 1
+    fi
+  fi
 
-  # 4. Copy settings.local.json
-  run "cp '$SETTINGS_LOCAL' '$worktree_path/.claude/settings.local.json'"
+  # 4. Copy settings.local.json (fail loudly if this can't happen)
+  if [[ "$DRY_RUN" -eq 0 ]]; then
+    if ! cp "$SETTINGS_LOCAL" "$worktree_path/.claude/settings.local.json"; then
+      echo "FAIL: could not copy settings.local.json into $worktree_path — aborting"
+      (cd "$PROJECT_DIR" && git worktree remove --force "$worktree_path") 2>/dev/null
+      return 1
+    fi
+  fi
 
   # 5. lefthook install in worktree
   if [[ -f "$worktree_path/lefthook.yml" || -f "$worktree_path/lefthook.yaml" ]]; then

--- a/scripts/spawn-workstream-windows.sh
+++ b/scripts/spawn-workstream-windows.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+# Spawns a fresh git worktree + Claude Code session per workstream ID.
+# Each worktree lives in ../online-chat-server-worktrees/<ws-id-lower>/ on
+# a new branch feature/<WS-ID>-autorun-<YYYYMMDD> off origin/develop.
+#
+# Usage:
+#   ./scripts/spawn-workstream-windows.sh [--dry-run] [--force] WS-01 WS-02 ...
+#
+# --dry-run: print actions, no side effects
+# --force:   bypass dependency gate (for testing)
+#
+# See docs/overnight-autonomous-run.md for the full flow.
+
+set -u
+
+DRY_RUN=0
+FORCE=0
+WS_IDS=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --force)   FORCE=1   ;;
+    -h|--help)
+      sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    WS-*) WS_IDS+=("$arg") ;;
+    *)
+      echo "Unknown arg: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ${#WS_IDS[@]} -eq 0 ]]; then
+  echo "Usage: $0 [--dry-run] [--force] WS-01 WS-02 ..." >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKTREE_PARENT="$(cd "$PROJECT_DIR/.." && pwd)/online-chat-server-worktrees"
+SETTINGS_LOCAL="$PROJECT_DIR/.claude/settings.local.json"
+WORKSTREAMS_DOC="$PROJECT_DIR/docs/workstreams/proposed-workstreams.md"
+DEP_MAP="$PROJECT_DIR/docs/workstreams/workstream-dependency-and-interface-map.md"
+PROMPT_DIR="/tmp"
+SPAWN_LOG="$HOME/.claude/cc-optimizer/spawn-log.jsonl"
+DATE_TAG=$(date +%Y%m%d)
+
+run() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "DRY: $*"
+  else
+    eval "$*"
+  fi
+}
+
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+[[ -f "$WORKSTREAMS_DOC" ]] || fail "workstreams doc not found at $WORKSTREAMS_DOC"
+[[ -f "$SETTINGS_LOCAL" ]] || fail "settings.local.json not found at $SETTINGS_LOCAL — create it before spawning"
+
+CODE_BIN=""
+for c in /opt/homebrew/bin/code /usr/local/bin/code; do
+  [[ -x "$c" ]] && CODE_BIN="$c" && break
+done
+
+CLAUDE_BIN=""
+for c in /opt/homebrew/bin/claude /usr/local/bin/claude "$HOME/.claude/local/claude"; do
+  [[ -x "$c" ]] && CLAUDE_BIN="$c" && break
+done
+[[ -n "$CLAUDE_BIN" ]] || fail "claude CLI not found — install it or adjust PATH"
+
+mkdir -p "$WORKTREE_PARENT"
+mkdir -p "$(dirname "$SPAWN_LOG")"
+
+generate_starter_prompt() {
+  local ws_id="$1"
+  local out="$2"
+  cat > "$out" <<PROMPT_EOF
+You are working ONLY on workstream $ws_id. Do not touch other workstreams' files.
+
+Before starting:
+1. Read CLAUDE.md \u00a76 (hard constraints) and docs/ai-development-guardrails.md \u00a75 and \u00a711.
+2. Read ONLY the rows in docs/traceability.md that match AC IDs for $ws_id.
+3. Read the $ws_id paragraph in docs/workstreams/proposed-workstreams.md. Skip other paragraphs.
+4. Read the $ws_id section of docs/workstreams/workstream-dependency-and-interface-map.md to understand what your workstream produces and consumes.
+
+Scope discipline:
+- You may ONLY edit files that belong to $ws_id. If you are unsure whether a file belongs to your workstream, stop and write the question to docs/workstream-notes/${ws_id,,}-blockers.md.
+- Before running \`docker compose up\`, run \`docker compose ps\`. If services are already running, reuse them \u2014 do NOT start a second instance.
+- If a git command fails with a lock error (\".git/index.lock\"), wait 5 seconds and retry once. Other workstream worktrees may be writing concurrently.
+
+Work rhythm:
+- One AC at a time. After each AC is delivered, commit with message format \"<AC-ID>: <what>\" and push to origin.
+- After your FIRST commit on this branch, open a DRAFT PR to develop:
+    gh pr create --draft --base develop --head feature/${ws_id}-autorun-${DATE_TAG} --label autorun --title "${ws_id} autorun" --body "Autonomous overnight run for ${ws_id}. Draft \u2014 human review required before merge."
+  The \`autorun\` label is what the cascade coordinator watches for. Each push re-triggers CodeRabbit + CI.
+- After each commit, update docs/traceability.md with the completion note for that AC row.
+- If you are not 100% certain about an AC, interpretation, API contract, or product decision: STOP. Do not guess. Write the question to docs/workstream-notes/${ws_id,,}-blockers.md and end your turn with a clear "BLOCKED: <why>" message.
+- maxTurns=80. Near the cap, commit in-progress work cleanly and STOP rather than leaving a change mid-way.
+
+End-of-workstream polish phase (MANDATORY before ending the session):
+1. After your last AC is delivered and pushed, wait ~5 minutes so CodeRabbit has time to post its review.
+2. Fetch review state: \`gh pr view <num> --json reviews,comments\`.
+3. For each actionable CodeRabbit comment: either fix (commit + push) or reply with a clear rationale. Mark threads resolved via \`gh api ...\` or the GitHub API.
+4. Repeat the fetch-address-push loop until CodeRabbit's latest review is APPROVED or every comment has an explicit resolution.
+5. Mark the PR ready (remove draft): \`gh pr ready <num>\`.
+6. Post the cascade-ready marker as a PR comment: \`gh pr comment <num> --body "<!-- autorun: ready-for-merge -->"\`.
+7. Only THEN end your session cleanly. Do not merge the PR yourself \u2014 cascade coordinator or a human handles merge.
+
+Context preservation:
+- Use the Explore subagent for broad codebase searches. Don't dump raw search results into your main context.
+- Write interim findings into docs/workstream-notes/${ws_id,,}-progress.md, not your head.
+- After each AC is delivered, consider /compact to start the next AC on fresh context.
+
+You are now in charge. Begin.
+PROMPT_EOF
+}
+
+check_dependencies() {
+  local ws_id="$1"
+  if [[ ! -f "$DEP_MAP" ]]; then
+    echo "WARN: dependency map missing at $DEP_MAP \u2014 skipping dependency check"
+    return 0
+  fi
+  # Look for "depends on" lines near the ws_id section. Heuristic only.
+  local deps
+  deps=$(awk -v target="$ws_id" '
+    BEGIN { in_section=0 }
+    /^#+/ {
+      if ($0 ~ target) { in_section=1 } else if (in_section==1) { in_section=0 }
+    }
+    in_section==1 && /[Dd]epend/ { print }
+  ' "$DEP_MAP" | grep -oE 'WS-[0-9]+' | sort -u | grep -v "^${ws_id}$")
+
+  if [[ -z "$deps" ]]; then
+    echo "no declared dependencies for $ws_id"
+    return 0
+  fi
+
+  echo "$ws_id depends on: $(echo $deps | tr '\n' ' ')"
+
+  if [[ "$FORCE" -eq 1 ]]; then
+    echo "  (\u2014\u2014force bypasses dependency gate)"
+    return 0
+  fi
+
+  local unmet=()
+  for dep in $deps; do
+    # Heuristic: check origin/develop log for a commit mentioning this dep
+    local merged
+    merged=$(cd "$PROJECT_DIR" && git log origin/develop --oneline --grep="$dep" 2>/dev/null | head -1)
+    if [[ -z "$merged" ]]; then
+      unmet+=("$dep")
+    fi
+  done
+
+  if [[ ${#unmet[@]} -gt 0 ]]; then
+    echo "UNMET dependencies: ${unmet[*]}"
+    echo "Rerun with --force to bypass (for testing), or wait for those workstreams to land on develop."
+    return 1
+  fi
+  return 0
+}
+
+spawn_one() {
+  local ws_id="$1"
+  local ws_lower
+  ws_lower=$(echo "$ws_id" | tr '[:upper:]' '[:lower:]')
+  local worktree_path="$WORKTREE_PARENT/$ws_lower"
+  local branch="feature/${ws_id}-autorun-${DATE_TAG}"
+  local prompt_file="$PROMPT_DIR/cc-starter-${ws_lower}.md"
+
+  echo
+  echo "=== Spawning $ws_id ==="
+
+  # 1. Validate existence in workstreams doc
+  if ! grep -qE "^\s*#+\s*.*${ws_id}" "$WORKSTREAMS_DOC" && ! grep -qE "${ws_id}" "$WORKSTREAMS_DOC"; then
+    echo "SKIP: $ws_id not found in $WORKSTREAMS_DOC"
+    return 1
+  fi
+
+  # 2. Dependency check
+  if ! check_dependencies "$ws_id"; then
+    return 1
+  fi
+
+  # 3. Worktree creation
+  if [[ -d "$worktree_path" ]]; then
+    echo "SKIP: worktree already exists at $worktree_path (remove first with: git worktree remove $worktree_path)"
+    return 1
+  fi
+  run "cd '$PROJECT_DIR' && git worktree add -b '$branch' '$worktree_path' origin/develop"
+
+  # 4. Copy settings.local.json
+  run "cp '$SETTINGS_LOCAL' '$worktree_path/.claude/settings.local.json'"
+
+  # 5. lefthook install in worktree
+  if [[ -f "$worktree_path/lefthook.yml" || -f "$worktree_path/lefthook.yaml" ]]; then
+    run "(cd '$worktree_path' && lefthook install >/dev/null 2>&1) || true"
+  fi
+
+  # 6. Generate starter prompt
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "DRY: would write starter prompt to $prompt_file"
+  else
+    generate_starter_prompt "$ws_id" "$prompt_file"
+  fi
+
+  # 7. Log spawn
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local log_entry
+  log_entry=$(jq -cn \
+    --arg ts "$ts" \
+    --arg ws "$ws_id" \
+    --arg wt "$worktree_path" \
+    --arg br "$branch" \
+    '{ts: $ts, ws_id: $ws, worktree_path: $wt, branch: $br}')
+  run "printf '%s\n' '$log_entry' >> '$SPAWN_LOG'"
+
+  # 8. Open terminal + run claude CLI with stdin prompt
+  local launch_cmd="cd '$worktree_path' && '$CLAUDE_BIN' < '$prompt_file'; exec \$SHELL"
+  local osa_script
+  osa_script=$(cat <<OSA
+tell application "Terminal"
+  activate
+  do script "$launch_cmd"
+end tell
+OSA
+)
+  run "osascript -e '$osa_script'"
+
+  echo "Spawned $ws_id in $worktree_path"
+}
+
+FAILURES=0
+for ws in "${WS_IDS[@]}"; do
+  if ! spawn_one "$ws"; then
+    FAILURES=$((FAILURES + 1))
+  fi
+done
+
+echo
+if [[ "$FAILURES" -eq 0 ]]; then
+  echo "All ${#WS_IDS[@]} workstream(s) spawned."
+else
+  echo "$FAILURES of ${#WS_IDS[@]} spawn(s) failed. See output above."
+  exit 1
+fi

--- a/scripts/spawn-workstream-windows.sh
+++ b/scripts/spawn-workstream-windows.sh
@@ -236,8 +236,9 @@ echo "=== Claude Code session for $ws_id ==="
 echo "Worktree: $worktree_path"
 echo "Branch: $branch"
 echo "Prompt file: $prompt_file"
+echo "Permission mode: bypassPermissions (via CLI + settings.local.json)"
 echo
-"$CLAUDE_BIN" < "$prompt_file"
+"$CLAUDE_BIN" --permission-mode bypassPermissions < "$prompt_file"
 echo
 echo "=== Session ended. Window stays open. ==="
 exec \$SHELL

--- a/scripts/spawn-workstream-windows.sh
+++ b/scripts/spawn-workstream-windows.sh
@@ -25,10 +25,16 @@ for arg in "$@"; do
       sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
-    WS-*) WS_IDS+=("$arg") ;;
     *)
-      echo "Unknown arg: $arg" >&2
-      exit 2
+      # Strictly validate workstream IDs: WS- then exactly two digits.
+      # Anything else (including WS-1 or WS-01extra or WS-01'evil) is rejected.
+      # This closes a shell-injection path: these IDs flow into command strings.
+      if [[ "$arg" =~ ^WS-[0-9]{2}$ ]]; then
+        WS_IDS+=("$arg")
+      else
+        echo "Unknown arg or invalid workstream ID: $arg (expected WS-NN)" >&2
+        exit 2
+      fi
       ;;
   esac
 done
@@ -48,15 +54,13 @@ PROMPT_DIR="/tmp"
 SPAWN_LOG="$HOME/.claude/cc-optimizer/spawn-log.jsonl"
 DATE_TAG=$(date +%Y%m%d)
 
-run() {
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    echo "DRY: $*"
-  else
-    eval "$*"
-  fi
-}
-
 fail() { echo "ERROR: $*" >&2; exit 1; }
+
+# `run_dry` is a thin wrapper for dry-run echoing ONLY. Callers pass a
+# descriptive string; real execution is inlined at the call site using
+# an argv array (never `eval`) to avoid shell-injection via variable
+# interpolation of externally-derived values (branch names, paths, etc.).
+dry_log() { echo "DRY: $*"; }
 
 [[ -f "$WORKSTREAMS_DOC" ]] || fail "workstreams doc not found at $WORKSTREAMS_DOC"
 [[ -f "$SETTINGS_LOCAL" ]] || fail "settings.local.json not found at $SETTINGS_LOCAL — create it before spawning"
@@ -72,8 +76,10 @@ for c in /opt/homebrew/bin/claude /usr/local/bin/claude "$HOME/.claude/local/cla
 done
 [[ -n "$CLAUDE_BIN" ]] || fail "claude CLI not found — install it or adjust PATH"
 
-mkdir -p "$WORKTREE_PARENT"
-mkdir -p "$(dirname "$SPAWN_LOG")"
+if [[ "$DRY_RUN" -eq 0 ]]; then
+  mkdir -p "$WORKTREE_PARENT"
+  mkdir -p "$(dirname "$SPAWN_LOG")"
+fi
 
 generate_starter_prompt() {
   local ws_id="$1"
@@ -121,7 +127,7 @@ Work rhythm:
 <None, or list destructive SQL operations and link to the migration file>"
   The \`autorun\` label is what the cascade coordinator watches for. Each push re-triggers CodeRabbit + CI.
 - After each commit, update docs/traceability.md with the completion note for that AC row.
-- If you are not 100% certain about an AC, interpretation, API contract, or product decision: STOP. Do not guess. Write the question to docs/workstream-notes/${ws_lower}-blockers.md, commit+push that note, open the draft PR with title prefix "${ws_id} autorun (BLOCKED — <short reason>)", then add the \`blocked\` label: \`gh pr edit <num> --add-label blocked\`. The Stop hook recognizes that label and lets you exit cleanly. The cascade coordinator also skips blocked-labeled PRs. End your turn with a clear "BLOCKED: <why>" message.
+- If you are not 100% certain about an AC, interpretation, API contract, or product decision: STOP. Do not guess. Write the question to docs/workstream-notes/${ws_lower}-blockers.md, commit+push that note, open the draft PR with a format-compliant title that carries the BLOCKED marker — the title must still pass \`check-pr-title\`. Use the pattern: \`chore: BLOCKED — ${ws_id} — <short reason>\` (the \`chore:\` prefix satisfies the format check). Then add the \`blocked\` label: \`gh pr edit <num> --add-label blocked\`. The Stop hook recognizes that label and lets you exit cleanly. The cascade coordinator also skips blocked-labeled PRs. End your turn with a clear "BLOCKED: <why>" message.
 - maxTurns=80. Near the cap, commit in-progress work cleanly and STOP rather than leaving a change mid-way.
 
 End-of-workstream polish phase (MANDATORY before ending the session):
@@ -183,13 +189,15 @@ check_dependencies() {
     if [[ -n "$merged" ]]; then
       continue
     fi
-    # Heuristic 2: traceability.md has a row mentioning the dep with a
-    # completion-ish status keyword nearby. Catches the case where the work
-    # was delivered under a different AC family than the WS-ID (e.g., WS-01
-    # delivered via AC-BOOT-00 in Phase 0).
-    if [[ -f "$trace_doc" ]] && grep -A 2 -B 2 "$dep" "$trace_doc" 2>/dev/null | \
-       grep -iqE "implemented|delivered|complete|landed|merged|✅|✓"; then
-      echo "  $dep satisfied via traceability.md completion marker"
+    # Heuristic 2: traceability.md has a line where the dep ID appears
+    # ON THE SAME LINE as a completion-ish status keyword. Same-line anchoring
+    # prevents false positives when a neighboring row carries a status word.
+    # Catches the case where the work was delivered under a different AC family
+    # than the WS-ID (e.g., WS-01 delivered via AC-BOOT-00 in Phase 0).
+    if [[ -f "$trace_doc" ]] && \
+       grep -iE "${dep}.*(implemented|delivered|complete|landed|merged|✅|✓)|(implemented|delivered|complete|landed|merged|✅|✓).*${dep}" \
+         "$trace_doc" >/dev/null 2>&1; then
+      echo "  $dep satisfied via traceability.md completion marker (same-line)"
       continue
     fi
     unmet+=("$dep")
@@ -214,9 +222,10 @@ spawn_one() {
   echo
   echo "=== Spawning $ws_id ==="
 
-  # 1. Validate existence in workstreams doc
-  if ! grep -qE "^\s*#+\s*.*${ws_id}" "$WORKSTREAMS_DOC" && ! grep -qE "${ws_id}" "$WORKSTREAMS_DOC"; then
-    echo "SKIP: $ws_id not found in $WORKSTREAMS_DOC"
+  # 1. Validate existence — require a proper section heading, not a loose
+  # mention in a "Consumes" or "Key integration points" line.
+  if ! grep -qE "^#+\s+.*${ws_id}" "$WORKSTREAMS_DOC"; then
+    echo "SKIP: $ws_id has no dedicated section heading in $WORKSTREAMS_DOC"
     return 1
   fi
 
@@ -252,37 +261,63 @@ spawn_one() {
     fi
   fi
 
-  # 5. lefthook install in worktree
+  # Helper: tear down the worktree + branch on fail-fast so a partial spawn
+  # doesn't leave garbage. Use inside the real-run error paths below.
+  rollback_worktree() {
+    local reason="$1"
+    echo "FAIL ($reason) — rolling back worktree + branch for $ws_id" >&2
+    (cd "$PROJECT_DIR" && git worktree remove --force "$worktree_path") 2>/dev/null
+    (cd "$PROJECT_DIR" && git branch -D "$branch") 2>/dev/null
+  }
+
+  # 5. lefthook install in worktree (best-effort; not fatal if missing)
   if [[ -f "$worktree_path/lefthook.yml" || -f "$worktree_path/lefthook.yaml" ]]; then
-    run "(cd '$worktree_path' && lefthook install >/dev/null 2>&1) || true"
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      dry_log "(cd $worktree_path && lefthook install)"
+    else
+      (cd "$worktree_path" && lefthook install >/dev/null 2>&1) || true
+    fi
   fi
 
-  # 6. Generate starter prompt
+  # 6. Generate starter prompt — fatal if this fails.
   if [[ "$DRY_RUN" -eq 1 ]]; then
-    echo "DRY: would write starter prompt to $prompt_file"
+    dry_log "would write starter prompt to $prompt_file"
   else
-    generate_starter_prompt "$ws_id" "$prompt_file"
+    if ! generate_starter_prompt "$ws_id" "$prompt_file"; then
+      rollback_worktree "starter prompt generation failed"
+      return 1
+    fi
   fi
 
-  # 7. Log spawn
+  # 7. Log spawn — fatal if this fails.
   local ts
   ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   local log_entry
-  log_entry=$(jq -cn \
+  if ! log_entry=$(jq -cn \
     --arg ts "$ts" \
     --arg ws "$ws_id" \
     --arg wt "$worktree_path" \
     --arg br "$branch" \
-    '{ts: $ts, ws_id: $ws, worktree_path: $wt, branch: $br}')
-  run "printf '%s\n' '$log_entry' >> '$SPAWN_LOG'"
+    '{ts: $ts, ws_id: $ws, worktree_path: $wt, branch: $br}' 2>&1); then
+    [[ "$DRY_RUN" -eq 0 ]] && rollback_worktree "jq log entry failed: $log_entry"
+    return 1
+  fi
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    dry_log "append to $SPAWN_LOG: $log_entry"
+  else
+    if ! printf '%s\n' "$log_entry" >> "$SPAWN_LOG"; then
+      rollback_worktree "spawn-log append failed"
+      return 1
+    fi
+  fi
 
   # 8. Open a Terminal window that runs the claude CLI with the starter prompt on stdin.
   # Using `open -a Terminal <file>` avoids macOS AppleEvent (osascript) automation perms.
   local launcher_sh="/tmp/cc-launch-${ws_lower}.sh"
   if [[ "$DRY_RUN" -eq 1 ]]; then
-    echo "DRY: would write $launcher_sh and run: open -a Terminal $launcher_sh"
+    dry_log "would write $launcher_sh and run: open -a Terminal $launcher_sh"
   else
-    cat > "$launcher_sh" <<LAUNCH_EOF
+    if ! cat > "$launcher_sh" <<LAUNCH_EOF
 #!/bin/bash
 cd "$worktree_path"
 echo "=== Claude Code session for $ws_id ==="
@@ -296,8 +331,18 @@ echo
 echo "=== Session ended. Window stays open. ==="
 exec \$SHELL
 LAUNCH_EOF
-    chmod +x "$launcher_sh"
-    open -a Terminal "$launcher_sh"
+    then
+      rollback_worktree "launcher script write failed"
+      return 1
+    fi
+    if ! chmod +x "$launcher_sh"; then
+      rollback_worktree "launcher chmod failed"
+      return 1
+    fi
+    if ! open -a Terminal "$launcher_sh"; then
+      rollback_worktree "open -a Terminal failed"
+      return 1
+    fi
   fi
 
   echo "Spawned $ws_id in $worktree_path"

--- a/scripts/spawn-workstream-windows.sh
+++ b/scripts/spawn-workstream-windows.sh
@@ -78,6 +78,8 @@ mkdir -p "$(dirname "$SPAWN_LOG")"
 generate_starter_prompt() {
   local ws_id="$1"
   local out="$2"
+  local ws_lower
+  ws_lower=$(echo "$ws_id" | tr '[:upper:]' '[:lower:]')
   cat > "$out" <<PROMPT_EOF
 You are working ONLY on workstream $ws_id. Do not touch other workstreams' files.
 
@@ -88,7 +90,7 @@ Before starting:
 4. Read the $ws_id section of docs/workstreams/workstream-dependency-and-interface-map.md to understand what your workstream produces and consumes.
 
 Scope discipline:
-- You may ONLY edit files that belong to $ws_id. If you are unsure whether a file belongs to your workstream, stop and write the question to docs/workstream-notes/${ws_id,,}-blockers.md.
+- You may ONLY edit files that belong to $ws_id. If you are unsure whether a file belongs to your workstream, stop and write the question to docs/workstream-notes/${ws_lower}-blockers.md.
 - Before running \`docker compose up\`, run \`docker compose ps\`. If services are already running, reuse them \u2014 do NOT start a second instance.
 - If a git command fails with a lock error (\".git/index.lock\"), wait 5 seconds and retry once. Other workstream worktrees may be writing concurrently.
 
@@ -98,7 +100,7 @@ Work rhythm:
     gh pr create --draft --base develop --head feature/${ws_id}-autorun-${DATE_TAG} --label autorun --title "${ws_id} autorun" --body "Autonomous overnight run for ${ws_id}. Draft \u2014 human review required before merge."
   The \`autorun\` label is what the cascade coordinator watches for. Each push re-triggers CodeRabbit + CI.
 - After each commit, update docs/traceability.md with the completion note for that AC row.
-- If you are not 100% certain about an AC, interpretation, API contract, or product decision: STOP. Do not guess. Write the question to docs/workstream-notes/${ws_id,,}-blockers.md and end your turn with a clear "BLOCKED: <why>" message.
+- If you are not 100% certain about an AC, interpretation, API contract, or product decision: STOP. Do not guess. Write the question to docs/workstream-notes/${ws_lower}-blockers.md and end your turn with a clear "BLOCKED: <why>" message.
 - maxTurns=80. Near the cap, commit in-progress work cleanly and STOP rather than leaving a change mid-way.
 
 End-of-workstream polish phase (MANDATORY before ending the session):
@@ -112,7 +114,7 @@ End-of-workstream polish phase (MANDATORY before ending the session):
 
 Context preservation:
 - Use the Explore subagent for broad codebase searches. Don't dump raw search results into your main context.
-- Write interim findings into docs/workstream-notes/${ws_id,,}-progress.md, not your head.
+- Write interim findings into docs/workstream-notes/${ws_lower}-progress.md, not your head.
 - After each AC is delivered, consider /compact to start the next AC on fresh context.
 
 You are now in charge. Begin.
@@ -221,17 +223,28 @@ spawn_one() {
     '{ts: $ts, ws_id: $ws, worktree_path: $wt, branch: $br}')
   run "printf '%s\n' '$log_entry' >> '$SPAWN_LOG'"
 
-  # 8. Open terminal + run claude CLI with stdin prompt
-  local launch_cmd="cd '$worktree_path' && '$CLAUDE_BIN' < '$prompt_file'; exec \$SHELL"
-  local osa_script
-  osa_script=$(cat <<OSA
-tell application "Terminal"
-  activate
-  do script "$launch_cmd"
-end tell
-OSA
-)
-  run "osascript -e '$osa_script'"
+  # 8. Open a Terminal window that runs the claude CLI with the starter prompt on stdin.
+  # Using `open -a Terminal <file>` avoids macOS AppleEvent (osascript) automation perms.
+  local launcher_sh="/tmp/cc-launch-${ws_lower}.sh"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "DRY: would write $launcher_sh and run: open -a Terminal $launcher_sh"
+  else
+    cat > "$launcher_sh" <<LAUNCH_EOF
+#!/bin/bash
+cd "$worktree_path"
+echo "=== Claude Code session for $ws_id ==="
+echo "Worktree: $worktree_path"
+echo "Branch: $branch"
+echo "Prompt file: $prompt_file"
+echo
+"$CLAUDE_BIN" < "$prompt_file"
+echo
+echo "=== Session ended. Window stays open. ==="
+exec \$SHELL
+LAUNCH_EOF
+    chmod +x "$launcher_sh"
+    open -a Terminal "$launcher_sh"
+  fi
 
   echo "Spawned $ws_id in $worktree_path"
 }

--- a/scripts/spawn-workstream-windows.sh
+++ b/scripts/spawn-workstream-windows.sh
@@ -253,9 +253,9 @@ echo "=== Claude Code session for $ws_id ==="
 echo "Worktree: $worktree_path"
 echo "Branch: $branch"
 echo "Prompt file: $prompt_file"
-echo "Permission mode: bypassPermissions (via CLI + settings.local.json)"
+echo "Permission mode: bypassPermissions (via settings.local.json defaultMode)"
 echo
-"$CLAUDE_BIN" --permission-mode bypassPermissions < "$prompt_file"
+"$CLAUDE_BIN" < "$prompt_file"
 echo
 echo "=== Session ended. Window stays open. ==="
 exec \$SHELL

--- a/scripts/spawn-workstream-windows.sh
+++ b/scripts/spawn-workstream-windows.sh
@@ -96,8 +96,29 @@ Scope discipline:
 
 Work rhythm:
 - One AC at a time. After each AC is delivered, commit with message format \"<AC-ID>: <what>\" and push to origin.
-- After your FIRST commit on this branch, open a DRAFT PR to develop:
-    gh pr create --draft --base develop --head feature/${ws_id}-autorun-${DATE_TAG} --label autorun --title "${ws_id} autorun" --body "Autonomous overnight run for ${ws_id}. Draft \u2014 human review required before merge."
+- After your FIRST commit on this branch, open a DRAFT PR to develop. The PR title and body MUST match the formats enforced by scripts/check-pr-description.ts and docs/git-workflow.md §4.1:
+  Title must start with one of: \`AC-<ID>:\`, \`chore:\`, \`fix:\`, \`doc:\`, \`infra:\`, \`spike:\` (or uppercase equivalents). For a multi-AC workstream PR, use the primary AC as the prefix:
+    AC-<PRIMARY-ID>: <short human summary> (${ws_id} autorun)
+  Body MUST include at minimum H2 sections \`## Summary\` and \`## Testing\`.
+  Use this template:
+    gh pr create --draft --base develop --head feature/${ws_id}-autorun-${DATE_TAG} --label autorun \\
+      --title "AC-<PRIMARY-ID>: <short summary> (${ws_id} autorun)" \\
+      --body "## Summary
+
+<one or two sentences describing what this workstream delivers>.
+
+## Testing
+
+<how ACs are exercised: which Playwright specs, which unit/integration tests, and any manual verification>.
+
+## AC IDs addressed
+- <AC-ID>: <name> (\\\`<spec path>\\\`)
+
+## Docs updated
+- <docs/* files touched and why>
+
+## Destructive-migration disclosure
+<None, or list destructive SQL operations and link to the migration file>"
   The \`autorun\` label is what the cascade coordinator watches for. Each push re-triggers CodeRabbit + CI.
 - After each commit, update docs/traceability.md with the completion note for that AC row.
 - If you are not 100% certain about an AC, interpretation, API contract, or product decision: STOP. Do not guess. Write the question to docs/workstream-notes/${ws_lower}-blockers.md, commit+push that note, open the draft PR with title prefix "${ws_id} autorun (BLOCKED — <short reason>)", then add the \`blocked\` label: \`gh pr edit <num> --add-label blocked\`. The Stop hook recognizes that label and lets you exit cleanly. The cascade coordinator also skips blocked-labeled PRs. End your turn with a clear "BLOCKED: <why>" message.
@@ -149,14 +170,25 @@ check_dependencies() {
     return 0
   fi
 
+  local trace_doc="$PROJECT_DIR/docs/traceability.md"
   local unmet=()
   for dep in $deps; do
-    # Heuristic: check origin/develop log for a commit mentioning this dep
+    # Heuristic 1: a commit on origin/develop mentions the dep.
     local merged
     merged=$(cd "$PROJECT_DIR" && git log origin/develop --oneline --grep="$dep" 2>/dev/null | head -1)
-    if [[ -z "$merged" ]]; then
-      unmet+=("$dep")
+    if [[ -n "$merged" ]]; then
+      continue
     fi
+    # Heuristic 2: traceability.md has a row mentioning the dep with a
+    # completion-ish status keyword nearby. Catches the case where the work
+    # was delivered under a different AC family than the WS-ID (e.g., WS-01
+    # delivered via AC-BOOT-00 in Phase 0).
+    if [[ -f "$trace_doc" ]] && grep -A 2 -B 2 "$dep" "$trace_doc" 2>/dev/null | \
+       grep -iqE "implemented|delivered|complete|landed|merged|✅|✓"; then
+      echo "  $dep satisfied via traceability.md completion marker"
+      continue
+    fi
+    unmet+=("$dep")
   done
 
   if [[ ${#unmet[@]} -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Three small, low-risk improvements to the overnight-autonomy infrastructure, surfaced while running WS-02 under the system for the first time.

## Testing

- Local `bash -n` syntax check on the launcher passes.
- `./scripts/spawn-workstream-windows.sh --dry-run WS-03` produces the expected output with the new dep-gate logic (no false positives for WS-03's empty dependency list).
- The `edited` trigger change is additive to existing pull_request activity types; no existing CI behavior regresses.
- The starter-prompt template produces PR title/body that pass the newly-merged `check-pr-title` and `check-pr-description` scripts on the first try (format: `AC-<ID>: <summary> (WS-XX autorun)` + `## Summary` + `## Testing`).

## Changes

1. **`.github/workflows/ci.yml`** — add `edited` to `pull_request` trigger types so PR title/body edits re-run format checks without needing an empty commit.
2. **`scripts/spawn-workstream-windows.sh` starter prompt** — replace the minimal PR title/body with a template matching docs/git-workflow.md §4.1 and the `check-pr-description` tool:
   - Title starts with `AC-<PRIMARY-ID>:` prefix.
   - Body contains H2 `## Summary` and `## Testing` sections.
   - Carries forward the `## AC IDs addressed` / `## Docs updated` / `## Destructive-migration disclosure` sections that worked well on WS-02.
3. **`scripts/spawn-workstream-windows.sh` dependency check** — new second heuristic: a dep WS-ID is considered satisfied if `docs/traceability.md` has a row mentioning it alongside a completion-ish keyword (implemented/delivered/complete/landed/merged/✅/✓). Catches the Phase-0-delivered case (WS-01 was delivered under AC-BOOT-00 commits that don't mention "WS-01").

## AC IDs addressed

None — infrastructure/chore PR. No product AC is advanced by this change; only autonomy-system quality improvements.
## Docs updated

None (scripts and CI config only).

## Destructive-migration disclosure

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed runbook for overnight autonomous workstreams with checklist, launch procedures, safety nets, and troubleshooting.

* **New Features**
  * Added a CLI tool to spawn isolated per-workstream worktrees, prepare starter prompts, and launch session instances.

* **Chores**
  * CI workflow now re-runs when a pull request’s title/body is edited.
  * Gitignore updated to exclude local Claude settings and runtime state files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->