### PR TITLE
AC-MSG-01: WS-04 messaging, history, DM, read-state (WS-04 autorun)

### DIFF
--- a/apps/api/drizzle/0004_ws04_messaging.sql
+++ b/apps/api/drizzle/0004_ws04_messaging.sql
@@ -1,0 +1,45 @@
+-- WS-04 messaging and durable history: messages, chat_read_state.
+-- Mirrors apps/api/src/db/schema/{messages,chat-read-state}.ts and
+-- data-model.md §4.13 and §4.16.
+
+CREATE TABLE IF NOT EXISTS messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  chat_id UUID NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+  sequence BIGINT NOT NULL,
+  author_user_id UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  kind TEXT NOT NULL DEFAULT 'text'
+    CHECK (kind IN ('text', 'system', 'attachment')),
+  body_text TEXT,
+  reply_to_message_id UUID REFERENCES messages(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  edited_at TIMESTAMPTZ,
+  deleted_at TIMESTAMPTZ,
+  deleted_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  metadata_json JSONB,
+  CONSTRAINT messages_sequence_positive CHECK (sequence > 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS messages_chat_sequence_uq
+  ON messages (chat_id, sequence);
+CREATE INDEX IF NOT EXISTS messages_chat_sequence_desc_idx
+  ON messages (chat_id, sequence DESC);
+CREATE INDEX IF NOT EXISTS messages_chat_created_idx
+  ON messages (chat_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS messages_author_created_idx
+  ON messages (author_user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS messages_reply_to_idx
+  ON messages (reply_to_message_id);
+
+CREATE TABLE IF NOT EXISTS chat_read_state (
+  chat_id UUID NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  last_read_sequence BIGINT NOT NULL DEFAULT 0,
+  last_opened_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (chat_id, user_id),
+  CONSTRAINT chat_read_state_last_read_nonneg CHECK (last_read_sequence >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS chat_read_state_user_idx
+  ON chat_read_state (user_id, updated_at DESC);

--- a/apps/api/src/db/schema/chat-read-state.ts
+++ b/apps/api/src/db/schema/chat-read-state.ts
@@ -1,0 +1,32 @@
+import { pgTable, timestamp, uuid, bigint, primaryKey, index, check } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { chats } from './chats.js';
+import { users } from './users.js';
+
+// Maps to data-model.md §4.16. One row per `(chat_id, user_id)` pair.
+// Absence of a row means "never opened"; the AC-UNREAD-01/02 query must
+// LEFT JOIN and treat the missing row as last_read_sequence=0.
+export const chatReadState = pgTable(
+  'chat_read_state',
+  {
+    chatId: uuid('chat_id')
+      .notNull()
+      .references(() => chats.id, { onDelete: 'cascade' }),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    lastReadSequence: bigint('last_read_sequence', { mode: 'number' }).notNull().default(0),
+    lastOpenedAt: timestamp('last_opened_at', { withTimezone: true }),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .default(sql`NOW()`),
+  },
+  (t) => [
+    primaryKey({ columns: [t.chatId, t.userId] }),
+    check('chat_read_state_last_read_nonneg', sql`${t.lastReadSequence} >= 0`),
+    index('chat_read_state_user_idx').on(t.userId, sql`updated_at DESC`),
+  ],
+);
+
+export type ChatReadStateRow = typeof chatReadState.$inferSelect;
+export type NewChatReadStateRow = typeof chatReadState.$inferInsert;

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -10,3 +10,5 @@ export * from './direct-chat-participants.js';
 export * from './friend-requests.js';
 export * from './friendships.js';
 export * from './user-blocks.js';
+export * from './messages.js';
+export * from './chat-read-state.js';

--- a/apps/api/src/db/schema/messages.ts
+++ b/apps/api/src/db/schema/messages.ts
@@ -1,0 +1,64 @@
+import {
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+  bigint,
+  index,
+  uniqueIndex,
+  jsonb,
+  check,
+  type AnyPgColumn,
+} from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { chats } from './chats.js';
+import { users } from './users.js';
+
+// Maps to data-model.md §4.13. `sequence` is chat-local and allocated by
+// the send-message transaction in apps/api/src/modules/messages/repository.ts.
+// The partial unique index on `(chat_id, sequence)` plus the CHECK on
+// `sequence > 0` are the DB-side guarantees that a dropped allocation
+// path cannot persist a duplicate or zero-sequence row.
+export const messages = pgTable(
+  'messages',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    chatId: uuid('chat_id')
+      .notNull()
+      .references(() => chats.id, { onDelete: 'cascade' }),
+    sequence: bigint('sequence', { mode: 'number' }).notNull(),
+    authorUserId: uuid('author_user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'restrict' }),
+    kind: text('kind', { enum: ['text', 'system', 'attachment'] })
+      .notNull()
+      .default('text'),
+    bodyText: text('body_text'),
+    replyToMessageId: uuid('reply_to_message_id').references((): AnyPgColumn => messages.id, {
+      onDelete: 'set null',
+    }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .default(sql`NOW()`),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .default(sql`NOW()`),
+    editedAt: timestamp('edited_at', { withTimezone: true }),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+    deletedByUserId: uuid('deleted_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    metadataJson: jsonb('metadata_json'),
+  },
+  (t) => [
+    uniqueIndex('messages_chat_sequence_uq').on(t.chatId, t.sequence),
+    check('messages_sequence_positive', sql`${t.sequence} > 0`),
+    index('messages_chat_sequence_desc_idx').on(t.chatId, sql`sequence DESC`),
+    index('messages_chat_created_idx').on(t.chatId, sql`created_at DESC`),
+    index('messages_author_created_idx').on(t.authorUserId, sql`created_at DESC`),
+    index('messages_reply_to_idx').on(t.replyToMessageId),
+  ],
+);
+
+export type MessageRow = typeof messages.$inferSelect;
+export type NewMessageRow = typeof messages.$inferInsert;

--- a/apps/api/src/modules/messages/errors.ts
+++ b/apps/api/src/modules/messages/errors.ts
@@ -1,0 +1,3 @@
+import { DomainError } from '../../shared/domain-error.js';
+
+export class MessageError extends DomainError {}

--- a/apps/api/src/modules/messages/index.ts
+++ b/apps/api/src/modules/messages/index.ts
@@ -1,0 +1,12 @@
+export { messagesRoutes } from './routes.js';
+export { MessageError } from './errors.js';
+export {
+  advanceReadState,
+  deleteMessage,
+  editOwnMessage,
+  fetchMessagesForChat,
+  fetchReadState,
+  messageRowToPublic,
+  sendDirectMessage,
+  sendMessageToChat,
+} from './service.js';

--- a/apps/api/src/modules/messages/repository.ts
+++ b/apps/api/src/modules/messages/repository.ts
@@ -404,8 +404,13 @@ export async function createDirectChatAndInsertMessage(params: {
 }
 
 export async function findUserActive(userId: string): Promise<{ id: string } | undefined> {
+  // `status = 'active'` should be sufficient since the soft-delete writer
+  // flips both fields in lockstep, but belt-and-braces matches the
+  // convention used by `getReadState` and other chat-side queries.
   const rows = await pgSql<{ id: string }[]>`
-    SELECT id FROM users WHERE id = ${userId} AND status = 'active' LIMIT 1
+    SELECT id FROM users
+    WHERE id = ${userId} AND status = 'active' AND deleted_at IS NULL
+    LIMIT 1
   `;
   return rows[0];
 }

--- a/apps/api/src/modules/messages/repository.ts
+++ b/apps/api/src/modules/messages/repository.ts
@@ -95,29 +95,117 @@ export async function hasActiveBlockBetween(aUserId: string, bUserId: string): P
   return rows.length > 0;
 }
 
+// Authorization scopes that callers pass down to repository mutations so
+// the relevant predicate (room membership, DM eligibility, DM
+// participation) is re-asserted atomically in the mutation SQL itself.
+// Without this, a revocation that commits between the service-level
+// preflight and the repository write (left_at set, friendship ended,
+// block added) would still let the mutation commit against stale auth.
+export type WriteAuthScope =
+  | { kind: 'room'; userId: string }
+  | { kind: 'direct'; userId: string; otherUserId: string };
+
+export type DeleteAuthScope =
+  | { kind: 'room'; callerUserId: string }
+  | { kind: 'direct' };
+
+export type ReadAuthScope =
+  | { kind: 'room'; userId: string }
+  | { kind: 'direct'; userId: string };
+
+// EXISTS (...) fragment: caller still has an active membership row in
+// the given room chat. Correlated via a literal chatId so the predicate
+// can be dropped into any outer WHERE clause.
+function callerIsActiveRoomMember(chatId: string, userId: string) {
+  return sql`EXISTS (
+    SELECT 1 FROM ${roomMemberships}
+    WHERE ${roomMemberships.roomChatId} = ${chatId}
+      AND ${roomMemberships.userId} = ${userId}
+      AND ${roomMemberships.leftAt} IS NULL
+  )`;
+}
+
+// EXISTS (...) fragment: caller is still a participant on the given
+// direct chat. Direct-chat participants don't get revoked in the current
+// schema, but including the check keeps the predicate symmetric with the
+// room-side one and guards future schema changes.
+function callerIsDmParticipant(chatId: string, userId: string) {
+  return sql`EXISTS (
+    SELECT 1 FROM ${directChatParticipants}
+    WHERE ${directChatParticipants.chatId} = ${chatId}
+      AND ${directChatParticipants.userId} = ${userId}
+  )`;
+}
+
+// Combined fragment: participant AND active friendship AND no active
+// block in either direction. Same semantics as the service-side
+// preflight in `requireChatWriteAccess` but evaluated atomically with
+// the mutation's UPDATE/INSERT statement.
+function dmPairStillEligible(chatId: string, callerUserId: string, otherUserId: string) {
+  const [low, high] =
+    callerUserId < otherUserId ? [callerUserId, otherUserId] : [otherUserId, callerUserId];
+  return sql`(
+    ${callerIsDmParticipant(chatId, callerUserId)}
+    AND EXISTS (
+      SELECT 1 FROM ${friendships}
+      WHERE ${friendships.userLowId} = ${low}
+        AND ${friendships.userHighId} = ${high}
+        AND ${friendships.endedAt} IS NULL
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM ${userBlocks}
+      WHERE ((${userBlocks.blockerUserId} = ${callerUserId} AND ${userBlocks.blockedUserId} = ${otherUserId})
+          OR (${userBlocks.blockerUserId} = ${otherUserId} AND ${userBlocks.blockedUserId} = ${callerUserId}))
+        AND ${userBlocks.removedAt} IS NULL
+    )
+  )`;
+}
+
+function buildWriteAuthPredicate(chatId: string, scope: WriteAuthScope) {
+  return scope.kind === 'room'
+    ? callerIsActiveRoomMember(chatId, scope.userId)
+    : dmPairStillEligible(chatId, scope.userId, scope.otherUserId);
+}
+
+function buildReadAuthPredicate(chatId: string, scope: ReadAuthScope) {
+  return scope.kind === 'room'
+    ? callerIsActiveRoomMember(chatId, scope.userId)
+    : callerIsDmParticipant(chatId, scope.userId);
+}
+
 export interface InsertMessageParams {
   chatId: string;
   authorUserId: string;
   bodyText: string;
   replyToMessageId?: string | null;
+  authScope: WriteAuthScope;
 }
 
 // Atomically increments the chat's `current_sequence` and inserts the
 // message with the allocated value. The `UPDATE ... RETURNING
 // current_sequence` guarantees exactly one allocation per caller even
 // under concurrent `POST /chats/{id}/messages` calls because the row
-// lock serialises them.
+// lock serialises them. The `authScope` predicate (active room
+// membership OR active DM eligibility) is folded into the UPDATE's
+// WHERE clause so a revocation that commits between the service-level
+// preflight and this statement causes the UPDATE to match zero rows —
+// the caller sees `undefined` and surfaces 403/404.
 export async function insertMessageWithSequence(
   params: InsertMessageParams,
-): Promise<{ message: MessageRow; nextSequence: number }> {
+): Promise<{ message: MessageRow; nextSequence: number } | undefined> {
   return db.transaction(async (tx) => {
+    const authPredicate = buildWriteAuthPredicate(params.chatId, params.authScope);
     const [updatedChat] = await tx
       .update(chats)
       .set({ currentSequence: sql`${chats.currentSequence} + 1` })
-      .where(and(eq(chats.id, params.chatId), isNull(chats.deletedAt)))
+      .where(and(eq(chats.id, params.chatId), isNull(chats.deletedAt), authPredicate))
       .returning({ currentSequence: chats.currentSequence });
     if (updatedChat === undefined) {
-      throw new Error('insertMessageWithSequence: chat not found or deleted');
+      // Chat was soft-deleted, the caller left the room, or the DM
+      // eligibility (friendship/block) flipped between preflight and
+      // here. Return undefined so the service can map to the right
+      // status without guessing which revocation won the race.
+      return undefined;
     }
     const nextSequence = updatedChat.currentSequence;
     const [row] = await tx
@@ -155,30 +243,62 @@ const parentChatIsActive = sql`EXISTS (
 
 export async function updateMessageBody(params: {
   messageId: string;
+  chatId: string;
   authorUserId: string;
   bodyText: string;
+  authScope: WriteAuthScope;
 }): Promise<MessageRow | undefined> {
   const now = new Date();
+  const authPredicate = buildWriteAuthPredicate(params.chatId, params.authScope);
   const [row] = await db
     .update(messages)
     .set({ bodyText: params.bodyText, editedAt: now, updatedAt: now })
     .where(
       and(
         eq(messages.id, params.messageId),
+        eq(messages.chatId, params.chatId),
         eq(messages.authorUserId, params.authorUserId),
         isNull(messages.deletedAt),
         parentChatIsActive,
+        authPredicate,
       ),
     )
     .returning();
   return row;
 }
 
+// `softDeleteMessage` authorizes against three possible shapes:
+//
+// - Room, caller is the message author: active room membership only.
+// - Room, caller is a moderator: active room membership with admin/owner role.
+// - Direct chat: no atomic predicate beyond `parentChatIsActive`, because
+//   the service already asserts caller == author and direct-chat
+//   participants don't get revoked in the current schema.
+//
+// The room predicate combines "caller is author" and "caller has
+// moderator role" into a single EXISTS subquery that references the
+// outer `messages.author_user_id`, so the UPDATE atomically verifies
+// the caller is still entitled to delete this specific message.
 export async function softDeleteMessage(params: {
   messageId: string;
+  chatId: string;
   deletedByUserId: string;
+  authScope: DeleteAuthScope;
 }): Promise<MessageRow | undefined> {
   const now = new Date();
+  const authPredicate =
+    params.authScope.kind === 'room'
+      ? sql`EXISTS (
+          SELECT 1 FROM ${roomMemberships}
+          WHERE ${roomMemberships.roomChatId} = ${params.chatId}
+            AND ${roomMemberships.userId} = ${params.authScope.callerUserId}
+            AND ${roomMemberships.leftAt} IS NULL
+            AND (
+              ${roomMemberships.userId} = ${messages.authorUserId}
+              OR ${roomMemberships.role} IN ('admin', 'owner')
+            )
+        )`
+      : sql`TRUE`;
   const [row] = await db
     .update(messages)
     .set({
@@ -189,8 +309,10 @@ export async function softDeleteMessage(params: {
     .where(
       and(
         eq(messages.id, params.messageId),
+        eq(messages.chatId, params.chatId),
         isNull(messages.deletedAt),
         parentChatIsActive,
+        authPredicate,
       ),
     )
     .returning();
@@ -199,6 +321,7 @@ export async function softDeleteMessage(params: {
 
 export interface ListMessagesParams {
   chatId: string;
+  authScope: ReadAuthScope;
   beforeSequence?: number | undefined;
   afterSequence?: number | undefined;
   limit: number;
@@ -211,8 +334,11 @@ export interface ListMessagesParams {
 // than the reported `headSequence`, and a concurrent soft-delete of
 // the chat could let history leak past the tombstone. The
 // `sequence <= chat.currentSequence` predicate clamps to the snapshot
-// head; the `deleted_at IS NULL` check returns `undefined` so the
-// caller can map to a 404.
+// head; the `deleted_at IS NULL` check plus the `authScope` predicate
+// (active room membership / DM participation) return `undefined` when
+// the caller lost read access between the preflight and this query —
+// the caller maps that to 404 so ex-members can't page past-tombstone
+// history.
 export async function loadActiveChatMessageSnapshot(params: ListMessagesParams): Promise<
   | {
       chat: ChatRow;
@@ -221,10 +347,11 @@ export async function loadActiveChatMessageSnapshot(params: ListMessagesParams):
   | undefined
 > {
   return db.transaction(async (tx) => {
+    const authPredicate = buildReadAuthPredicate(params.chatId, params.authScope);
     const chatRows = await tx
       .select()
       .from(chats)
-      .where(and(eq(chats.id, params.chatId), isNull(chats.deletedAt)))
+      .where(and(eq(chats.id, params.chatId), isNull(chats.deletedAt), authPredicate))
       .limit(1);
     const chat = chatRows[0];
     if (chat === undefined) return undefined;
@@ -294,6 +421,18 @@ export interface FirstDirectMessageResult {
   message: MessageRow;
 }
 
+// Sentinel thrown from inside `createDirectChatAndInsertMessage` when
+// friendship or block state flips between the service-level preflight
+// and the tx body. The service catches this and maps to
+// `DM_NOT_ALLOWED`/403 so the caller sees the same response as if the
+// preflight had rejected it.
+export class DmEligibilityRevokedError extends Error {
+  constructor() {
+    super('DM eligibility revoked during send');
+    this.name = 'DmEligibilityRevokedError';
+  }
+}
+
 // Creates a direct chat (if missing), then allocates and inserts the
 // first message. Re-used for subsequent sends as long as the caller is
 // still authorized; the `chatCreated` flag tells the client whether this
@@ -321,6 +460,40 @@ export async function createDirectChatAndInsertMessage(params: {
     await tx.execute(
       sql`SELECT pg_advisory_xact_lock(hashtextextended(${low} || '|' || ${high}, 0))`,
     );
+
+    // Re-verify DM eligibility inside the tx, under the advisory lock,
+    // so a friendship-end or block-add that commits between the
+    // service-level preflight and here is caught. SELECT FOR UPDATE on
+    // the friendship row prevents a concurrent end-friendship UPDATE
+    // from committing until our tx settles; the block SELECT is a
+    // best-effort re-read (a brand-new block row has nothing for us to
+    // lock, but if it committed before our statement it's visible
+    // here). Both checks mirror `requireChatWriteAccess` exactly so
+    // revocation semantics stay consistent between preflight and
+    // atomic-commit.
+    const friendshipRows = await tx
+      .select({ endedAt: friendships.endedAt })
+      .from(friendships)
+      .where(and(eq(friendships.userLowId, low), eq(friendships.userHighId, high)))
+      .for('update')
+      .limit(1);
+    if (friendshipRows.length === 0 || friendshipRows[0]?.endedAt !== null) {
+      throw new DmEligibilityRevokedError();
+    }
+    const blockRows = await tx
+      .select({ id: userBlocks.id })
+      .from(userBlocks)
+      .where(
+        and(
+          isNull(userBlocks.removedAt),
+          sql`((${userBlocks.blockerUserId} = ${params.senderUserId} AND ${userBlocks.blockedUserId} = ${params.recipientUserId})
+            OR (${userBlocks.blockerUserId} = ${params.recipientUserId} AND ${userBlocks.blockedUserId} = ${params.senderUserId}))`,
+        ),
+      )
+      .limit(1);
+    if (blockRows.length > 0) {
+      throw new DmEligibilityRevokedError();
+    }
 
     // Find the single chat both participants share. The `innerJoin` +
     // `EXISTS` subquery expresses the symmetric pair lookup through
@@ -438,18 +611,43 @@ function mapRawReadState(row: RawChatReadStateRow): ChatReadStateRow {
   };
 }
 
+// Builds an AND-prefixed postgres-js fragment that asserts the caller
+// still has read access to chat `c`. The fragment is embedded into the
+// WHERE clauses of the read-state queries below so the membership /
+// participation check runs atomically with the chat row selection — a
+// left_at/removed_at commit between the service-level preflight and
+// the query causes zero rows and the caller maps to 404.
+function buildRawReadAuthFragment(scope: ReadAuthScope) {
+  if (scope.kind === 'room') {
+    return pgSql`AND EXISTS (
+      SELECT 1 FROM room_memberships rm
+      WHERE rm.room_chat_id = c.id
+        AND rm.user_id = ${scope.userId}
+        AND rm.left_at IS NULL
+    )`;
+  }
+  return pgSql`AND EXISTS (
+    SELECT 1 FROM direct_chat_participants p
+    WHERE p.chat_id = c.id
+      AND p.user_id = ${scope.userId}
+  )`;
+}
+
 export async function upsertReadState(params: {
   chatId: string;
   userId: string;
   readUpToSequence: number;
+  authScope: ReadAuthScope;
 }): Promise<ChatReadStateRow | undefined> {
-  // INSERT ... SELECT against chats with `deleted_at IS NULL`: if the
-  // chat is soft-deleted between service-level authz and this upsert,
-  // the SELECT returns zero rows, no INSERT happens, the ON CONFLICT
-  // path does not fire, and RETURNING yields nothing. The caller maps
-  // that to a 404 so read-state can't be clamped against a tombstoned
-  // chat. EXCLUDED.last_read_sequence reuses the SELECT-clamped value
-  // on the conflict path so it stays consistent with the insert path.
+  // INSERT ... SELECT against chats with `deleted_at IS NULL` plus the
+  // caller's read-auth predicate: if the chat is soft-deleted OR the
+  // caller lost membership/participation between service-level authz
+  // and this upsert, the SELECT returns zero rows, no INSERT happens,
+  // the ON CONFLICT path does not fire, and RETURNING yields nothing.
+  // The caller maps that to a 404 so ex-members can't clamp read-state
+  // against a tombstoned or newly-inaccessible chat.
+  // EXCLUDED.last_read_sequence reuses the SELECT-clamped value on the
+  // conflict path so it stays consistent with the insert path.
   //
   // Note: we intentionally let postgres set the timestamps via NOW() rather
   // than passing a Date from JS. Postgres-js's raw tagged-template path
@@ -457,6 +655,7 @@ export async function upsertReadState(params: {
   // from `Buffer.byteLength` when it tries to wire a Date), so using NOW()
   // on the server side both avoids that pitfall and keeps read-state
   // timestamps in DB-clock time.
+  const authFragment = buildRawReadAuthFragment(params.authScope);
   const rows = await pgSql<RawChatReadStateRow[]>`
     INSERT INTO chat_read_state (chat_id, user_id, last_read_sequence, last_opened_at, updated_at)
     SELECT
@@ -466,7 +665,7 @@ export async function upsertReadState(params: {
       NOW(),
       NOW()
     FROM chats c
-    WHERE c.id = ${params.chatId} AND c.deleted_at IS NULL
+    WHERE c.id = ${params.chatId} AND c.deleted_at IS NULL ${authFragment}
     ON CONFLICT (chat_id, user_id) DO UPDATE
     SET
       last_read_sequence = GREATEST(
@@ -485,7 +684,9 @@ export async function upsertReadState(params: {
 export async function getReadState(params: {
   chatId: string;
   userId: string;
+  authScope: ReadAuthScope;
 }): Promise<{ lastReadSequence: number; headSequence: number } | undefined> {
+  const authFragment = buildRawReadAuthFragment(params.authScope);
   const rows = await pgSql<
     {
       last_read_sequence: string | number;
@@ -498,7 +699,7 @@ export async function getReadState(params: {
     FROM chats c
     LEFT JOIN chat_read_state rs
       ON rs.chat_id = c.id AND rs.user_id = ${params.userId}
-    WHERE c.id = ${params.chatId} AND c.deleted_at IS NULL
+    WHERE c.id = ${params.chatId} AND c.deleted_at IS NULL ${authFragment}
     LIMIT 1
   `;
   const first = rows[0];

--- a/apps/api/src/modules/messages/repository.ts
+++ b/apps/api/src/modules/messages/repository.ts
@@ -1,0 +1,433 @@
+import { and, desc, eq, gt, isNull, lt, sql } from 'drizzle-orm';
+import { db, pgSql } from '../../db/client.js';
+import { messages, type MessageRow } from '../../db/schema/messages.js';
+import { chats, type ChatRow } from '../../db/schema/chats.js';
+import { roomMemberships } from '../../db/schema/room-memberships.js';
+import { directChatParticipants } from '../../db/schema/direct-chat-participants.js';
+import { rooms } from '../../db/schema/rooms.js';
+import type { ChatReadStateRow } from '../../db/schema/chat-read-state.js';
+import { friendships } from '../../db/schema/friendships.js';
+import { userBlocks } from '../../db/schema/user-blocks.js';
+
+export interface ChatContext {
+  chat: ChatRow;
+  roomOwnerUserId: string | null;
+  directParticipantIds: string[] | null;
+}
+
+export async function loadChatContext(chatId: string): Promise<ChatContext | undefined> {
+  const chatRows = await db
+    .select()
+    .from(chats)
+    .where(and(eq(chats.id, chatId), isNull(chats.deletedAt)))
+    .limit(1);
+  const chat = chatRows[0];
+  if (chat === undefined) return undefined;
+  if (chat.type === 'room') {
+    const roomRows = await db
+      .select({ ownerUserId: rooms.ownerUserId })
+      .from(rooms)
+      .where(and(eq(rooms.chatId, chatId), isNull(rooms.deletedAt)))
+      .limit(1);
+    const owner = roomRows[0]?.ownerUserId ?? null;
+    return { chat, roomOwnerUserId: owner, directParticipantIds: null };
+  }
+  const participantRows = await db
+    .select({ userId: directChatParticipants.userId })
+    .from(directChatParticipants)
+    .where(eq(directChatParticipants.chatId, chatId));
+  return {
+    chat,
+    roomOwnerUserId: null,
+    directParticipantIds: participantRows.map((r) => r.userId),
+  };
+}
+
+export async function isActiveRoomMember(
+  roomChatId: string,
+  userId: string,
+): Promise<{ role: 'owner' | 'admin' | 'member' } | undefined> {
+  const rows = await db
+    .select({ role: roomMemberships.role })
+    .from(roomMemberships)
+    .where(
+      and(
+        eq(roomMemberships.roomChatId, roomChatId),
+        eq(roomMemberships.userId, userId),
+        isNull(roomMemberships.leftAt),
+      ),
+    )
+    .limit(1);
+  return rows[0];
+}
+
+export async function hasActiveFriendship(aUserId: string, bUserId: string): Promise<boolean> {
+  const [low, high] = aUserId < bUserId ? [aUserId, bUserId] : [bUserId, aUserId];
+  const rows = await db
+    .select({ id: friendships.id })
+    .from(friendships)
+    .where(
+      and(
+        eq(friendships.userLowId, low),
+        eq(friendships.userHighId, high),
+        isNull(friendships.endedAt),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+export async function hasActiveBlockBetween(aUserId: string, bUserId: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: userBlocks.id })
+    .from(userBlocks)
+    .where(
+      and(
+        isNull(userBlocks.removedAt),
+        sql`(
+          (${userBlocks.blockerUserId} = ${aUserId} AND ${userBlocks.blockedUserId} = ${bUserId})
+          OR
+          (${userBlocks.blockerUserId} = ${bUserId} AND ${userBlocks.blockedUserId} = ${aUserId})
+        )`,
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+export interface InsertMessageParams {
+  chatId: string;
+  authorUserId: string;
+  bodyText: string;
+  replyToMessageId?: string | null;
+}
+
+// Atomically increments the chat's `current_sequence` and inserts the
+// message with the allocated value. The `UPDATE ... RETURNING
+// current_sequence` guarantees exactly one allocation per caller even
+// under concurrent `POST /chats/{id}/messages` calls because the row
+// lock serialises them.
+export async function insertMessageWithSequence(
+  params: InsertMessageParams,
+): Promise<{ message: MessageRow; nextSequence: number }> {
+  return db.transaction(async (tx) => {
+    const [updatedChat] = await tx
+      .update(chats)
+      .set({ currentSequence: sql`${chats.currentSequence} + 1` })
+      .where(and(eq(chats.id, params.chatId), isNull(chats.deletedAt)))
+      .returning({ currentSequence: chats.currentSequence });
+    if (updatedChat === undefined) {
+      throw new Error('insertMessageWithSequence: chat not found or deleted');
+    }
+    const nextSequence = updatedChat.currentSequence;
+    const [row] = await tx
+      .insert(messages)
+      .values({
+        chatId: params.chatId,
+        sequence: nextSequence,
+        authorUserId: params.authorUserId,
+        kind: 'text',
+        bodyText: params.bodyText,
+        replyToMessageId: params.replyToMessageId ?? null,
+      })
+      .returning();
+    if (row === undefined) {
+      throw new Error('insertMessageWithSequence: insert returned no row');
+    }
+    return { message: row, nextSequence };
+  });
+}
+
+export async function findMessageById(messageId: string): Promise<MessageRow | undefined> {
+  const rows = await db.select().from(messages).where(eq(messages.id, messageId)).limit(1);
+  return rows[0];
+}
+
+export async function updateMessageBody(params: {
+  messageId: string;
+  authorUserId: string;
+  bodyText: string;
+}): Promise<MessageRow | undefined> {
+  const now = new Date();
+  const [row] = await db
+    .update(messages)
+    .set({ bodyText: params.bodyText, editedAt: now, updatedAt: now })
+    .where(
+      and(
+        eq(messages.id, params.messageId),
+        eq(messages.authorUserId, params.authorUserId),
+        isNull(messages.deletedAt),
+      ),
+    )
+    .returning();
+  return row;
+}
+
+export async function softDeleteMessage(params: {
+  messageId: string;
+  deletedByUserId: string;
+}): Promise<MessageRow | undefined> {
+  const now = new Date();
+  const [row] = await db
+    .update(messages)
+    .set({
+      deletedAt: now,
+      deletedByUserId: params.deletedByUserId,
+      updatedAt: now,
+    })
+    .where(and(eq(messages.id, params.messageId), isNull(messages.deletedAt)))
+    .returning();
+  return row;
+}
+
+export interface ListMessagesParams {
+  chatId: string;
+  beforeSequence?: number | undefined;
+  afterSequence?: number | undefined;
+  limit: number;
+}
+
+export async function listMessages(params: ListMessagesParams): Promise<MessageRow[]> {
+  const predicates = [eq(messages.chatId, params.chatId)];
+  if (params.beforeSequence !== undefined) {
+    predicates.push(lt(messages.sequence, params.beforeSequence));
+  }
+  if (params.afterSequence !== undefined) {
+    predicates.push(gt(messages.sequence, params.afterSequence));
+  }
+  return db
+    .select()
+    .from(messages)
+    .where(and(...predicates))
+    .orderBy(desc(messages.sequence))
+    .limit(params.limit);
+}
+
+export async function findDirectChatBetween(
+  aUserId: string,
+  bUserId: string,
+): Promise<ChatRow | undefined> {
+  // A direct chat is identified by the two participant rows both
+  // pointing at the same chat. The `innerJoin` picks the caller's side;
+  // the `EXISTS` subquery asserts the other participant is present too.
+  // The `deleted_at IS NULL` filter keeps historically frozen-then-purged
+  // chats from resurrecting.
+  const rows = await db
+    .select({
+      id: chats.id,
+      type: chats.type,
+      currentSequence: chats.currentSequence,
+      createdAt: chats.createdAt,
+      deletedAt: chats.deletedAt,
+    })
+    .from(chats)
+    .innerJoin(
+      directChatParticipants,
+      and(
+        eq(directChatParticipants.chatId, chats.id),
+        eq(directChatParticipants.userId, aUserId),
+      ),
+    )
+    .where(
+      and(
+        eq(chats.type, 'direct'),
+        isNull(chats.deletedAt),
+        sql`EXISTS (
+          SELECT 1 FROM direct_chat_participants p2
+          WHERE p2.chat_id = ${chats.id} AND p2.user_id = ${bUserId}
+        )`,
+      ),
+    )
+    .limit(1);
+  return rows[0];
+}
+
+export interface FirstDirectMessageResult {
+  chat: ChatRow;
+  chatCreated: boolean;
+  message: MessageRow;
+}
+
+// Creates a direct chat (if missing), then allocates and inserts the
+// first message. Re-used for subsequent sends as long as the caller is
+// still authorized; the `chatCreated` flag tells the client whether this
+// call materialized the chat.
+export async function createDirectChatAndInsertMessage(params: {
+  senderUserId: string;
+  recipientUserId: string;
+  bodyText: string;
+  replyToMessageId?: string | null;
+}): Promise<FirstDirectMessageResult> {
+  return db.transaction(async (tx) => {
+    // Find the single chat both participants share. The `innerJoin` +
+    // `EXISTS` subquery expresses the symmetric pair lookup through
+    // Drizzle's typed query builder, so the returned row comes back as a
+    // `ChatRow` without needing raw SQL casts. The deleted_at filter
+    // keeps historically frozen-then-purged chats from resurrecting.
+    const existingRows = await tx
+      .select({
+        id: chats.id,
+        type: chats.type,
+        currentSequence: chats.currentSequence,
+        createdAt: chats.createdAt,
+        deletedAt: chats.deletedAt,
+      })
+      .from(chats)
+      .innerJoin(
+        directChatParticipants,
+        and(
+          eq(directChatParticipants.chatId, chats.id),
+          eq(directChatParticipants.userId, params.senderUserId),
+        ),
+      )
+      .where(
+        and(
+          eq(chats.type, 'direct'),
+          isNull(chats.deletedAt),
+          sql`EXISTS (
+            SELECT 1 FROM direct_chat_participants p2
+            WHERE p2.chat_id = ${chats.id} AND p2.user_id = ${params.recipientUserId}
+          )`,
+        ),
+      )
+      .limit(1)
+      .for('update');
+    const existing = existingRows[0];
+
+    let chatRow: ChatRow;
+    let chatCreated = false;
+    if (existing !== undefined) {
+      chatRow = existing;
+    } else {
+      const [createdChat] = await tx.insert(chats).values({ type: 'direct' }).returning();
+      if (createdChat === undefined) {
+        throw new Error('createDirectChatAndInsertMessage: chat insert failed');
+      }
+      await tx.insert(directChatParticipants).values([
+        { chatId: createdChat.id, userId: params.senderUserId },
+        { chatId: createdChat.id, userId: params.recipientUserId },
+      ]);
+      chatRow = createdChat;
+      chatCreated = true;
+    }
+
+    const [updatedChat] = await tx
+      .update(chats)
+      .set({ currentSequence: sql`${chats.currentSequence} + 1` })
+      .where(eq(chats.id, chatRow.id))
+      .returning({ currentSequence: chats.currentSequence });
+    if (updatedChat === undefined) {
+      throw new Error('createDirectChatAndInsertMessage: sequence bump failed');
+    }
+    const nextSequence = updatedChat.currentSequence;
+
+    const [messageRow] = await tx
+      .insert(messages)
+      .values({
+        chatId: chatRow.id,
+        sequence: nextSequence,
+        authorUserId: params.senderUserId,
+        kind: 'text',
+        bodyText: params.bodyText,
+        replyToMessageId: params.replyToMessageId ?? null,
+      })
+      .returning();
+    if (messageRow === undefined) {
+      throw new Error('createDirectChatAndInsertMessage: message insert failed');
+    }
+
+    return { chat: chatRow, chatCreated, message: messageRow };
+  });
+}
+
+export async function findUserActive(userId: string): Promise<{ id: string } | undefined> {
+  const rows = await pgSql<{ id: string }[]>`
+    SELECT id FROM users WHERE id = ${userId} AND status = 'active' LIMIT 1
+  `;
+  return rows[0];
+}
+
+interface RawChatReadStateRow {
+  chat_id: string;
+  user_id: string;
+  last_read_sequence: string | number;
+  last_opened_at: Date | string | null;
+  updated_at: Date | string;
+}
+
+function mapRawReadState(row: RawChatReadStateRow): ChatReadStateRow {
+  return {
+    chatId: row.chat_id,
+    userId: row.user_id,
+    lastReadSequence: Number(row.last_read_sequence),
+    lastOpenedAt:
+      row.last_opened_at === null
+        ? null
+        : row.last_opened_at instanceof Date
+          ? row.last_opened_at
+          : new Date(row.last_opened_at),
+    updatedAt: row.updated_at instanceof Date ? row.updated_at : new Date(row.updated_at),
+  };
+}
+
+export async function upsertReadState(params: {
+  chatId: string;
+  userId: string;
+  readUpToSequence: number;
+}): Promise<ChatReadStateRow> {
+  // Clamp to current head atomically: the subquery reads
+  // chats.current_sequence and uses LEAST so a client over-advance can't
+  // push lastReadSequence past head.
+  const now = new Date();
+  const rows = await pgSql<RawChatReadStateRow[]>`
+    INSERT INTO chat_read_state (chat_id, user_id, last_read_sequence, last_opened_at, updated_at)
+    VALUES (
+      ${params.chatId},
+      ${params.userId},
+      LEAST(${params.readUpToSequence}, COALESCE((SELECT current_sequence FROM chats WHERE id = ${params.chatId}), 0)),
+      ${now},
+      ${now}
+    )
+    ON CONFLICT (chat_id, user_id) DO UPDATE
+    SET
+      last_read_sequence = GREATEST(
+        chat_read_state.last_read_sequence,
+        LEAST(${params.readUpToSequence}, COALESCE((SELECT current_sequence FROM chats WHERE id = ${params.chatId}), 0))
+      ),
+      last_opened_at = ${now},
+      updated_at = ${now}
+    RETURNING *
+  `;
+  const first = rows[0];
+  if (first === undefined) {
+    throw new Error('upsertReadState: upsert returned no row');
+  }
+  return mapRawReadState(first);
+}
+
+export async function getReadState(params: {
+  chatId: string;
+  userId: string;
+}): Promise<{ lastReadSequence: number; headSequence: number } | undefined> {
+  const rows = await pgSql<
+    {
+      last_read_sequence: string | number;
+      head_sequence: string | number;
+    }[]
+  >`
+    SELECT
+      COALESCE(rs.last_read_sequence, 0) AS last_read_sequence,
+      c.current_sequence AS head_sequence
+    FROM chats c
+    LEFT JOIN chat_read_state rs
+      ON rs.chat_id = c.id AND rs.user_id = ${params.userId}
+    WHERE c.id = ${params.chatId} AND c.deleted_at IS NULL
+    LIMIT 1
+  `;
+  const first = rows[0];
+  if (first === undefined) return undefined;
+  return {
+    lastReadSequence: Number(first.last_read_sequence),
+    headSequence: Number(first.head_sequence),
+  };
+}

--- a/apps/api/src/modules/messages/repository.ts
+++ b/apps/api/src/modules/messages/repository.ts
@@ -259,6 +259,23 @@ export async function createDirectChatAndInsertMessage(params: {
   replyToMessageId?: string | null;
 }): Promise<FirstDirectMessageResult> {
   return db.transaction(async (tx) => {
+    // Serialize any concurrent first-DM attempts for the same ordered
+    // pair. Without this, two transactions could both fail the
+    // "existing direct chat" lookup, create distinct `chats` rows, and
+    // each insert their own `(chat_id, user_id)` pair — giving the pair
+    // two DMs and splitting history. The advisory lock is scoped to
+    // the transaction and uses a 64-bit hash of the sorted pair as the
+    // key; `hashtextextended` is a built-in and returns `bigint`, so
+    // there's no collision-class concern beyond ordinary hash birthday
+    // math for this in-process counter.
+    const [low, high] =
+      params.senderUserId < params.recipientUserId
+        ? [params.senderUserId, params.recipientUserId]
+        : [params.recipientUserId, params.senderUserId];
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtextextended(${low} || '|' || ${high}, 0))`,
+    );
+
     // Find the single chat both participants share. The `innerJoin` +
     // `EXISTS` subquery expresses the symmetric pair lookup through
     // Drizzle's typed query builder, so the returned row comes back as a
@@ -378,15 +395,21 @@ export async function upsertReadState(params: {
   // Clamp to current head atomically: the subquery reads
   // chats.current_sequence and uses LEAST so a client over-advance can't
   // push lastReadSequence past head.
-  const now = new Date();
+  //
+  // Note: we intentionally let postgres set the timestamps via NOW() rather
+  // than passing a Date from JS. Postgres-js's raw tagged-template path
+  // cannot bind a naked `Date` without a known column type hint (ERR_INVALID_ARG_TYPE
+  // from `Buffer.byteLength` when it tries to wire a Date), so using NOW()
+  // on the server side both avoids that pitfall and keeps read-state
+  // timestamps in DB-clock time.
   const rows = await pgSql<RawChatReadStateRow[]>`
     INSERT INTO chat_read_state (chat_id, user_id, last_read_sequence, last_opened_at, updated_at)
     VALUES (
       ${params.chatId},
       ${params.userId},
       LEAST(${params.readUpToSequence}, COALESCE((SELECT current_sequence FROM chats WHERE id = ${params.chatId}), 0)),
-      ${now},
-      ${now}
+      NOW(),
+      NOW()
     )
     ON CONFLICT (chat_id, user_id) DO UPDATE
     SET
@@ -394,8 +417,8 @@ export async function upsertReadState(params: {
         chat_read_state.last_read_sequence,
         LEAST(${params.readUpToSequence}, COALESCE((SELECT current_sequence FROM chats WHERE id = ${params.chatId}), 0))
       ),
-      last_opened_at = ${now},
-      updated_at = ${now}
+      last_opened_at = NOW(),
+      updated_at = NOW()
     RETURNING *
   `;
   const first = rows[0];

--- a/apps/api/src/modules/messages/repository.ts
+++ b/apps/api/src/modules/messages/repository.ts
@@ -204,20 +204,49 @@ export interface ListMessagesParams {
   limit: number;
 }
 
-export async function listMessages(params: ListMessagesParams): Promise<MessageRow[]> {
-  const predicates = [eq(messages.chatId, params.chatId)];
-  if (params.beforeSequence !== undefined) {
-    predicates.push(lt(messages.sequence, params.beforeSequence));
-  }
-  if (params.afterSequence !== undefined) {
-    predicates.push(gt(messages.sequence, params.afterSequence));
-  }
-  return db
-    .select()
-    .from(messages)
-    .where(and(...predicates))
-    .orderBy(desc(messages.sequence))
-    .limit(params.limit);
+// Loads the chat's current head-sequence and the requested page of
+// messages in a single transaction, so authz and listing see the same
+// chat snapshot. Without this, a concurrent send between
+// `loadChatContext()` and the list query could return messages newer
+// than the reported `headSequence`, and a concurrent soft-delete of
+// the chat could let history leak past the tombstone. The
+// `sequence <= chat.currentSequence` predicate clamps to the snapshot
+// head; the `deleted_at IS NULL` check returns `undefined` so the
+// caller can map to a 404.
+export async function loadActiveChatMessageSnapshot(params: ListMessagesParams): Promise<
+  | {
+      chat: ChatRow;
+      messages: MessageRow[];
+    }
+  | undefined
+> {
+  return db.transaction(async (tx) => {
+    const chatRows = await tx
+      .select()
+      .from(chats)
+      .where(and(eq(chats.id, params.chatId), isNull(chats.deletedAt)))
+      .limit(1);
+    const chat = chatRows[0];
+    if (chat === undefined) return undefined;
+
+    const predicates = [
+      eq(messages.chatId, params.chatId),
+      sql`${messages.sequence} <= ${chat.currentSequence}`,
+    ];
+    if (params.beforeSequence !== undefined) {
+      predicates.push(lt(messages.sequence, params.beforeSequence));
+    }
+    if (params.afterSequence !== undefined) {
+      predicates.push(gt(messages.sequence, params.afterSequence));
+    }
+    const rows = await tx
+      .select()
+      .from(messages)
+      .where(and(...predicates))
+      .orderBy(desc(messages.sequence))
+      .limit(params.limit);
+    return { chat, messages: rows };
+  });
 }
 
 export async function findDirectChatBetween(

--- a/apps/api/src/modules/messages/repository.ts
+++ b/apps/api/src/modules/messages/repository.ts
@@ -408,10 +408,14 @@ export async function upsertReadState(params: {
   chatId: string;
   userId: string;
   readUpToSequence: number;
-}): Promise<ChatReadStateRow> {
-  // Clamp to current head atomically: the subquery reads
-  // chats.current_sequence and uses LEAST so a client over-advance can't
-  // push lastReadSequence past head.
+}): Promise<ChatReadStateRow | undefined> {
+  // INSERT ... SELECT against chats with `deleted_at IS NULL`: if the
+  // chat is soft-deleted between service-level authz and this upsert,
+  // the SELECT returns zero rows, no INSERT happens, the ON CONFLICT
+  // path does not fire, and RETURNING yields nothing. The caller maps
+  // that to a 404 so read-state can't be clamped against a tombstoned
+  // chat. EXCLUDED.last_read_sequence reuses the SELECT-clamped value
+  // on the conflict path so it stays consistent with the insert path.
   //
   // Note: we intentionally let postgres set the timestamps via NOW() rather
   // than passing a Date from JS. Postgres-js's raw tagged-template path
@@ -421,27 +425,26 @@ export async function upsertReadState(params: {
   // timestamps in DB-clock time.
   const rows = await pgSql<RawChatReadStateRow[]>`
     INSERT INTO chat_read_state (chat_id, user_id, last_read_sequence, last_opened_at, updated_at)
-    VALUES (
-      ${params.chatId},
+    SELECT
+      c.id,
       ${params.userId},
-      LEAST(${params.readUpToSequence}, COALESCE((SELECT current_sequence FROM chats WHERE id = ${params.chatId}), 0)),
+      LEAST(${params.readUpToSequence}, COALESCE(c.current_sequence, 0)),
       NOW(),
       NOW()
-    )
+    FROM chats c
+    WHERE c.id = ${params.chatId} AND c.deleted_at IS NULL
     ON CONFLICT (chat_id, user_id) DO UPDATE
     SET
       last_read_sequence = GREATEST(
         chat_read_state.last_read_sequence,
-        LEAST(${params.readUpToSequence}, COALESCE((SELECT current_sequence FROM chats WHERE id = ${params.chatId}), 0))
+        EXCLUDED.last_read_sequence
       ),
       last_opened_at = NOW(),
       updated_at = NOW()
     RETURNING *
   `;
   const first = rows[0];
-  if (first === undefined) {
-    throw new Error('upsertReadState: upsert returned no row');
-  }
+  if (first === undefined) return undefined;
   return mapRawReadState(first);
 }
 

--- a/apps/api/src/modules/messages/repository.ts
+++ b/apps/api/src/modules/messages/repository.ts
@@ -143,6 +143,16 @@ export async function findMessageById(messageId: string): Promise<MessageRow | u
   return rows[0];
 }
 
+// Asserts the message's parent chat is still active. Without this,
+// a chat that gets soft-deleted after the service-level authz check
+// but before this UPDATE would still accept mutations on a tombstoned
+// chat. Expressed as an EXISTS subquery so the predicate lives inside
+// the UPDATE itself and the write fails atomically.
+const parentChatIsActive = sql`EXISTS (
+  SELECT 1 FROM ${chats}
+  WHERE ${chats.id} = ${messages.chatId} AND ${chats.deletedAt} IS NULL
+)`;
+
 export async function updateMessageBody(params: {
   messageId: string;
   authorUserId: string;
@@ -157,6 +167,7 @@ export async function updateMessageBody(params: {
         eq(messages.id, params.messageId),
         eq(messages.authorUserId, params.authorUserId),
         isNull(messages.deletedAt),
+        parentChatIsActive,
       ),
     )
     .returning();
@@ -175,7 +186,13 @@ export async function softDeleteMessage(params: {
       deletedByUserId: params.deletedByUserId,
       updatedAt: now,
     })
-    .where(and(eq(messages.id, params.messageId), isNull(messages.deletedAt)))
+    .where(
+      and(
+        eq(messages.id, params.messageId),
+        isNull(messages.deletedAt),
+        parentChatIsActive,
+      ),
+    )
     .returning();
   return row;
 }

--- a/apps/api/src/modules/messages/routes.ts
+++ b/apps/api/src/modules/messages/routes.ts
@@ -1,0 +1,231 @@
+import type { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
+import { Type } from '@sinclair/typebox';
+import {
+  AdvanceReadStateRequestSchema,
+  AdvanceReadStateResponseSchema,
+  DeleteMessageResponseSchema,
+  EditMessageRequestSchema,
+  EditMessageResponseSchema,
+  ErrorEnvelopeSchema,
+  ListMessagesQuerySchema,
+  ListMessagesResponseSchema,
+  ReadStateResponseSchema,
+  SendDirectMessageRequestSchema,
+  SendDirectMessageResponseSchema,
+  SendMessageRequestSchema,
+  SendMessageResponseSchema,
+} from 'shared-schemas';
+import { requireSession } from '../auth/plugin.js';
+import {
+  advanceReadState,
+  deleteMessage,
+  editOwnMessage,
+  fetchMessagesForChat,
+  fetchReadState,
+  messageRowToPublic,
+  sendDirectMessage,
+  sendMessageToChat,
+} from './service.js';
+
+const ChatParamsSchema = Type.Object({
+  chatId: Type.String({ format: 'uuid' }),
+});
+
+const MessageParamsSchema = Type.Object({
+  messageId: Type.String({ format: 'uuid' }),
+});
+
+const DmParamsSchema = Type.Object({
+  userId: Type.String({ format: 'uuid' }),
+});
+
+export const messagesRoutes: FastifyPluginAsyncTypebox = (fastify) => {
+  fastify.post(
+    '/chats/:chatId/messages',
+    {
+      schema: {
+        params: ChatParamsSchema,
+        body: SendMessageRequestSchema,
+        response: {
+          200: SendMessageResponseSchema,
+          400: ErrorEnvelopeSchema,
+          401: ErrorEnvelopeSchema,
+          403: ErrorEnvelopeSchema,
+          404: ErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const session = requireSession(req);
+      const row = await sendMessageToChat({
+        chatId: req.params.chatId,
+        senderUserId: session.user.id,
+        bodyText: req.body.bodyText,
+        replyToMessageId: req.body.replyToMessageId ?? null,
+      });
+      return reply.status(200).send({ data: { message: messageRowToPublic(row) } });
+    },
+  );
+
+  fastify.get(
+    '/chats/:chatId/messages',
+    {
+      schema: {
+        params: ChatParamsSchema,
+        querystring: ListMessagesQuerySchema,
+        response: {
+          200: ListMessagesResponseSchema,
+          401: ErrorEnvelopeSchema,
+          403: ErrorEnvelopeSchema,
+          404: ErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const session = requireSession(req);
+      const result = await fetchMessagesForChat({
+        chatId: req.params.chatId,
+        callerUserId: session.user.id,
+        ...(req.query.beforeSequence !== undefined
+          ? { beforeSequence: req.query.beforeSequence }
+          : {}),
+        ...(req.query.afterSequence !== undefined
+          ? { afterSequence: req.query.afterSequence }
+          : {}),
+        ...(req.query.limit !== undefined ? { limit: req.query.limit } : {}),
+      });
+      return reply.status(200).send({ data: result });
+    },
+  );
+
+  fastify.patch(
+    '/messages/:messageId',
+    {
+      schema: {
+        params: MessageParamsSchema,
+        body: EditMessageRequestSchema,
+        response: {
+          200: EditMessageResponseSchema,
+          400: ErrorEnvelopeSchema,
+          401: ErrorEnvelopeSchema,
+          403: ErrorEnvelopeSchema,
+          404: ErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const session = requireSession(req);
+      const row = await editOwnMessage({
+        messageId: req.params.messageId,
+        authorUserId: session.user.id,
+        bodyText: req.body.bodyText,
+      });
+      return reply.status(200).send({ data: { message: messageRowToPublic(row) } });
+    },
+  );
+
+  fastify.delete(
+    '/messages/:messageId',
+    {
+      schema: {
+        params: MessageParamsSchema,
+        response: {
+          200: DeleteMessageResponseSchema,
+          401: ErrorEnvelopeSchema,
+          403: ErrorEnvelopeSchema,
+          404: ErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const session = requireSession(req);
+      await deleteMessage({
+        messageId: req.params.messageId,
+        callerUserId: session.user.id,
+      });
+      return reply.status(200).send({ data: { ok: true } });
+    },
+  );
+
+  fastify.post(
+    '/dm/:userId/messages',
+    {
+      schema: {
+        params: DmParamsSchema,
+        body: SendDirectMessageRequestSchema,
+        response: {
+          200: SendDirectMessageResponseSchema,
+          400: ErrorEnvelopeSchema,
+          401: ErrorEnvelopeSchema,
+          403: ErrorEnvelopeSchema,
+          404: ErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const session = requireSession(req);
+      const result = await sendDirectMessage({
+        senderUserId: session.user.id,
+        recipientUserId: req.params.userId,
+        bodyText: req.body.bodyText,
+        replyToMessageId: req.body.replyToMessageId ?? null,
+      });
+      return reply.status(200).send({
+        data: {
+          chat: { id: result.chatId, created: result.chatCreated },
+          message: messageRowToPublic(result.message),
+        },
+      });
+    },
+  );
+
+  fastify.post(
+    '/chats/:chatId/read',
+    {
+      schema: {
+        params: ChatParamsSchema,
+        body: AdvanceReadStateRequestSchema,
+        response: {
+          200: AdvanceReadStateResponseSchema,
+          401: ErrorEnvelopeSchema,
+          403: ErrorEnvelopeSchema,
+          404: ErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const session = requireSession(req);
+      const result = await advanceReadState({
+        chatId: req.params.chatId,
+        userId: session.user.id,
+        readUpToSequence: req.body.readUpToSequence,
+      });
+      return reply.status(200).send({ data: result });
+    },
+  );
+
+  fastify.get(
+    '/chats/:chatId/read-state',
+    {
+      schema: {
+        params: ChatParamsSchema,
+        response: {
+          200: ReadStateResponseSchema,
+          401: ErrorEnvelopeSchema,
+          403: ErrorEnvelopeSchema,
+          404: ErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const session = requireSession(req);
+      const result = await fetchReadState({
+        chatId: req.params.chatId,
+        userId: session.user.id,
+      });
+      return reply.status(200).send({ data: result });
+    },
+  );
+
+  return Promise.resolve();
+};

--- a/apps/api/src/modules/messages/service.ts
+++ b/apps/api/src/modules/messages/service.ts
@@ -17,7 +17,7 @@ import {
   hasActiveFriendship,
   insertMessageWithSequence,
   isActiveRoomMember,
-  listMessages,
+  loadActiveChatMessageSnapshot,
   loadChatContext,
   softDeleteMessage,
   updateMessageBody,
@@ -298,16 +298,23 @@ export async function fetchMessagesForChat(input: {
     input.limit ?? PAGINATION_CURSOR_DEFAULT_LIMIT,
     PAGINATION_CURSOR_MAX_LIMIT,
   );
-  const rows = await listMessages({
+  // Fetch head-sequence and the page in one transaction so the
+  // response can't contain sequences newer than `headSequence` and so
+  // a concurrent soft-delete of the chat surfaces as 404 instead of
+  // leaking post-tombstone history.
+  const snapshot = await loadActiveChatMessageSnapshot({
     chatId: input.chatId,
     ...(input.beforeSequence !== undefined ? { beforeSequence: input.beforeSequence } : {}),
     ...(input.afterSequence !== undefined ? { afterSequence: input.afterSequence } : {}),
     limit,
   });
+  if (snapshot === undefined) {
+    throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Chat not found.');
+  }
   return {
     chatId: input.chatId,
-    headSequence: ctx.chat.currentSequence,
-    messages: rows.map(messageRowToPublic),
+    headSequence: snapshot.chat.currentSequence,
+    messages: snapshot.messages.map(messageRowToPublic),
   };
 }
 

--- a/apps/api/src/modules/messages/service.ts
+++ b/apps/api/src/modules/messages/service.ts
@@ -28,15 +28,18 @@ import {
 const TEXT_ENCODER = new TextEncoder();
 
 function validateBody(bodyText: string): string {
-  const trimmed = bodyText;
-  if (trimmed.length === 0) {
+  // Reject whitespace-only bodies: `'   '`, `'\n'`, etc. would otherwise
+  // persist as "real" messages that render blank in the UI. We still
+  // keep the original body (not trimmed) because leading/trailing
+  // whitespace inside a multi-line code paste can be meaningful.
+  if (bodyText.trim().length === 0) {
     throw new MessageError(ErrorCodes.VALIDATION_ERROR, 400, 'Message body cannot be empty.', {
       field: 'bodyText',
     });
   }
   // AC-MSG-02: measure the UTF-8 byte length, not the JS code-unit count,
   // so emoji and non-Latin scripts aren't accidentally allowed past 3 KB.
-  const bytes = TEXT_ENCODER.encode(trimmed).byteLength;
+  const bytes = TEXT_ENCODER.encode(bodyText).byteLength;
   if (bytes > MESSAGE_MAX_BYTES) {
     throw new MessageError(
       ErrorCodes.VALIDATION_ERROR,
@@ -45,7 +48,7 @@ function validateBody(bodyText: string): string {
       { field: 'bodyText', maxBytes: MESSAGE_MAX_BYTES, actualBytes: bytes },
     );
   }
-  return trimmed;
+  return bodyText;
 }
 
 async function requireChatWriteAccess(chatId: string, userId: string): Promise<ChatContext> {

--- a/apps/api/src/modules/messages/service.ts
+++ b/apps/api/src/modules/messages/service.ts
@@ -100,7 +100,15 @@ export async function sendMessageToChat(input: {
   await requireChatWriteAccess(input.chatId, input.senderUserId);
   if (input.replyToMessageId !== undefined && input.replyToMessageId !== null) {
     const replyTarget = await findMessageById(input.replyToMessageId);
-    if (replyTarget === undefined || replyTarget.chatId !== input.chatId) {
+    // Soft-deleted targets are indistinguishable from cold misses to the
+    // client: the body is already scrubbed on public render, so a reply
+    // quoting a tombstone would display as a dangling pointer. Reject
+    // them the same way we'd reject a non-existent target.
+    if (
+      replyTarget === undefined ||
+      replyTarget.deletedAt !== null ||
+      replyTarget.chatId !== input.chatId
+    ) {
       throw new MessageError(
         ErrorCodes.VALIDATION_ERROR,
         400,
@@ -162,7 +170,15 @@ export async function sendDirectMessage(input: {
     // valid when the chat is about to be created for the first time.
     const existing = await findDirectChatBetween(input.senderUserId, input.recipientUserId);
     const replyTarget = await findMessageById(input.replyToMessageId);
-    if (existing === undefined || replyTarget === undefined || replyTarget.chatId !== existing.id) {
+    // Same rationale as `sendMessageToChat`: a tombstoned reply target
+    // renders as a dangling pointer in the UI, so treat it like a cold
+    // miss instead of letting the reply record the FK.
+    if (
+      existing === undefined ||
+      replyTarget === undefined ||
+      replyTarget.deletedAt !== null ||
+      replyTarget.chatId !== existing.id
+    ) {
       throw new MessageError(
         ErrorCodes.VALIDATION_ERROR,
         400,

--- a/apps/api/src/modules/messages/service.ts
+++ b/apps/api/src/modules/messages/service.ts
@@ -9,6 +9,7 @@ import type { MessageRow } from '../../db/schema/messages.js';
 import { MessageError } from './errors.js';
 import {
   createDirectChatAndInsertMessage,
+  DmEligibilityRevokedError,
   findDirectChatBetween,
   findMessageById,
   findUserActive,
@@ -23,6 +24,8 @@ import {
   updateMessageBody,
   upsertReadState,
   type ChatContext,
+  type ReadAuthScope,
+  type WriteAuthScope,
 } from './repository.js';
 
 const TEXT_ENCODER = new TextEncoder();
@@ -49,6 +52,27 @@ function validateBody(bodyText: string): string {
     );
   }
   return bodyText;
+}
+
+// Translates a loaded ChatContext into the repository-side write scope
+// so the mutation SQL can atomically re-verify the same predicates that
+// `requireChatWriteAccess` just checked. The room scope captures the
+// caller's user id; the direct scope captures both participants so the
+// repository's friendship/block subqueries can be built without another
+// round trip to the DB.
+function buildWriteScope(ctx: ChatContext, userId: string): WriteAuthScope {
+  if (ctx.chat.type === 'room') return { kind: 'room', userId };
+  const otherUserId = ctx.directParticipantIds?.find((id) => id !== userId);
+  if (otherUserId === undefined) {
+    // `requireChatWriteAccess` has already rejected this shape, but
+    // defensive guard keeps the union exhaustive.
+    throw new MessageError(ErrorCodes.FORBIDDEN, 403, 'You are not a participant in this chat.');
+  }
+  return { kind: 'direct', userId, otherUserId };
+}
+
+function buildReadScope(ctx: ChatContext, userId: string): ReadAuthScope {
+  return ctx.chat.type === 'room' ? { kind: 'room', userId } : { kind: 'direct', userId };
 }
 
 async function requireChatWriteAccess(chatId: string, userId: string): Promise<ChatContext> {
@@ -97,7 +121,7 @@ export async function sendMessageToChat(input: {
   replyToMessageId?: string | null;
 }): Promise<MessageRow> {
   const body = validateBody(input.bodyText);
-  await requireChatWriteAccess(input.chatId, input.senderUserId);
+  const ctx = await requireChatWriteAccess(input.chatId, input.senderUserId);
   if (input.replyToMessageId !== undefined && input.replyToMessageId !== null) {
     const replyTarget = await findMessageById(input.replyToMessageId);
     // Soft-deleted targets are indistinguishable from cold misses to the
@@ -117,13 +141,25 @@ export async function sendMessageToChat(input: {
       );
     }
   }
-  const { message } = await insertMessageWithSequence({
+  const result = await insertMessageWithSequence({
     chatId: input.chatId,
     authorUserId: input.senderUserId,
     bodyText: body,
     replyToMessageId: input.replyToMessageId ?? null,
+    authScope: buildWriteScope(ctx, input.senderUserId),
   });
-  return message;
+  if (result === undefined) {
+    // The chat was soft-deleted, the caller's room membership was
+    // revoked, or the DM friendship/block flipped between the preflight
+    // and the insert. Surface it as a 403 mirroring the preflight's
+    // rejection shape.
+    throw new MessageError(
+      ErrorCodes.FORBIDDEN,
+      403,
+      'Lost write access to this chat before the message could be sent.',
+    );
+  }
+  return result.message;
 }
 
 export async function sendDirectMessage(input: {
@@ -188,17 +224,32 @@ export async function sendDirectMessage(input: {
     }
   }
 
-  const result = await createDirectChatAndInsertMessage({
-    senderUserId: input.senderUserId,
-    recipientUserId: input.recipientUserId,
-    bodyText: body,
-    replyToMessageId: input.replyToMessageId ?? null,
-  });
-  return {
-    message: result.message,
-    chatId: result.chat.id,
-    chatCreated: result.chatCreated,
-  };
+  try {
+    const result = await createDirectChatAndInsertMessage({
+      senderUserId: input.senderUserId,
+      recipientUserId: input.recipientUserId,
+      bodyText: body,
+      replyToMessageId: input.replyToMessageId ?? null,
+    });
+    return {
+      message: result.message,
+      chatId: result.chat.id,
+      chatCreated: result.chatCreated,
+    };
+  } catch (err) {
+    if (err instanceof DmEligibilityRevokedError) {
+      // Friendship ended or a block landed between the service-level
+      // preflight and the in-tx re-check. Surface the same
+      // DM_NOT_ALLOWED response shape the preflight would have thrown
+      // so callers don't have to special-case a race condition.
+      throw new MessageError(
+        ErrorCodes.DM_NOT_ALLOWED,
+        403,
+        'Direct messages are not allowed between these users.',
+      );
+    }
+    throw err;
+  }
 }
 
 export async function editOwnMessage(input: {
@@ -217,15 +268,20 @@ export async function editOwnMessage(input: {
   // Caller must still have write access to the containing chat (e.g.
   // banned from the room, DM became frozen). Re-using the same gate as
   // send keeps the rule in one place.
-  await requireChatWriteAccess(existing.chatId, input.authorUserId);
+  const ctx = await requireChatWriteAccess(existing.chatId, input.authorUserId);
   const updated = await updateMessageBody({
     messageId: input.messageId,
+    chatId: existing.chatId,
     authorUserId: input.authorUserId,
     bodyText: body,
+    authScope: buildWriteScope(ctx, input.authorUserId),
   });
   if (updated === undefined) {
-    // Another caller deleted the message between the lookup and the
-    // update. Surface the same 404 a cold caller would see.
+    // Either another caller deleted the message or the caller's write
+    // access was revoked (left the room, friendship ended, block
+    // added) between the preflight and the UPDATE. In both cases the
+    // caller can no longer see/mutate the message, so a 404 is the
+    // right response.
     throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Message not found.');
   }
   return updated;
@@ -272,9 +328,21 @@ export async function deleteMessage(input: {
   }
   const deleted = await softDeleteMessage({
     messageId: input.messageId,
+    chatId: existing.chatId,
     deletedByUserId: input.callerUserId,
+    // For rooms, the repository re-asserts membership AND (caller ==
+    // message.author OR role IN ('admin','owner')) atomically so a
+    // concurrent membership/role revocation can't slip past the
+    // preflight check above. Direct chats don't need an atomic
+    // predicate: the only change that matters is the chat being
+    // soft-deleted, which `parentChatIsActive` already covers.
+    authScope:
+      ctx.chat.type === 'room' ? { kind: 'room', callerUserId: input.callerUserId } : { kind: 'direct' },
   });
   if (deleted === undefined) {
+    // Message was already deleted, chat was soft-deleted, or room
+    // membership/role changed between the preflight and the UPDATE.
+    // 404 mirrors what a cold caller would see.
     throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Message not found.');
   }
 }
@@ -320,11 +388,16 @@ export async function fetchMessagesForChat(input: {
   // leaking post-tombstone history.
   const snapshot = await loadActiveChatMessageSnapshot({
     chatId: input.chatId,
+    authScope: buildReadScope(ctx, input.callerUserId),
     ...(input.beforeSequence !== undefined ? { beforeSequence: input.beforeSequence } : {}),
     ...(input.afterSequence !== undefined ? { afterSequence: input.afterSequence } : {}),
     limit,
   });
   if (snapshot === undefined) {
+    // Chat was soft-deleted OR the caller's read access was revoked
+    // (room membership ended) between the preflight check above and
+    // the snapshot query. Both cases collapse to 404 so a concurrent
+    // removal doesn't leak post-tombstone history.
     throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Chat not found.');
   }
   return {
@@ -356,11 +429,14 @@ export async function advanceReadState(input: {
     chatId: input.chatId,
     userId: input.userId,
     readUpToSequence: input.readUpToSequence,
+    authScope: buildReadScope(ctx, input.userId),
   });
   if (row === undefined) {
-    // Chat was soft-deleted between the authz check above and the
-    // upsert; the INSERT ... SELECT matched no active chat row so no
-    // read-state was written. Treat it the same as a cold 404.
+    // Either the chat was soft-deleted or the caller's room membership
+    // was revoked between the preflight and the upsert. The INSERT ...
+    // SELECT matched no row so no read-state was written. Treat it the
+    // same as a cold 404 to avoid leaking distinctions a caller without
+    // access couldn't observe anyway.
     throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Chat not found.');
   }
   return { chatId: input.chatId, lastReadSequence: row.lastReadSequence };
@@ -388,8 +464,11 @@ export async function fetchReadState(input: { chatId: string; userId: string }):
   const state = await getReadState({
     chatId: input.chatId,
     userId: input.userId,
+    authScope: buildReadScope(ctx, input.userId),
   });
   if (state === undefined) {
+    // Same reasoning as `advanceReadState`: chat soft-deleted or
+    // membership revoked collapses to a single 404 response.
     throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Chat not found.');
   }
   return {

--- a/apps/api/src/modules/messages/service.ts
+++ b/apps/api/src/modules/messages/service.ts
@@ -334,6 +334,12 @@ export async function advanceReadState(input: {
     userId: input.userId,
     readUpToSequence: input.readUpToSequence,
   });
+  if (row === undefined) {
+    // Chat was soft-deleted between the authz check above and the
+    // upsert; the INSERT ... SELECT matched no active chat row so no
+    // read-state was written. Treat it the same as a cold 404.
+    throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Chat not found.');
+  }
   return { chatId: input.chatId, lastReadSequence: row.lastReadSequence };
 }
 

--- a/apps/api/src/modules/messages/service.ts
+++ b/apps/api/src/modules/messages/service.ts
@@ -1,0 +1,384 @@
+import {
+  ErrorCodes,
+  MESSAGE_MAX_BYTES,
+  PAGINATION_CURSOR_DEFAULT_LIMIT,
+  PAGINATION_CURSOR_MAX_LIMIT,
+  type MessagePublic,
+} from 'shared-schemas';
+import type { MessageRow } from '../../db/schema/messages.js';
+import { MessageError } from './errors.js';
+import {
+  createDirectChatAndInsertMessage,
+  findDirectChatBetween,
+  findMessageById,
+  findUserActive,
+  getReadState,
+  hasActiveBlockBetween,
+  hasActiveFriendship,
+  insertMessageWithSequence,
+  isActiveRoomMember,
+  listMessages,
+  loadChatContext,
+  softDeleteMessage,
+  updateMessageBody,
+  upsertReadState,
+  type ChatContext,
+} from './repository.js';
+
+const TEXT_ENCODER = new TextEncoder();
+
+function validateBody(bodyText: string): string {
+  const trimmed = bodyText;
+  if (trimmed.length === 0) {
+    throw new MessageError(ErrorCodes.VALIDATION_ERROR, 400, 'Message body cannot be empty.', {
+      field: 'bodyText',
+    });
+  }
+  // AC-MSG-02: measure the UTF-8 byte length, not the JS code-unit count,
+  // so emoji and non-Latin scripts aren't accidentally allowed past 3 KB.
+  const bytes = TEXT_ENCODER.encode(trimmed).byteLength;
+  if (bytes > MESSAGE_MAX_BYTES) {
+    throw new MessageError(
+      ErrorCodes.VALIDATION_ERROR,
+      400,
+      'Message body exceeds the 3 KB limit.',
+      { field: 'bodyText', maxBytes: MESSAGE_MAX_BYTES, actualBytes: bytes },
+    );
+  }
+  return trimmed;
+}
+
+async function requireChatWriteAccess(chatId: string, userId: string): Promise<ChatContext> {
+  const ctx = await loadChatContext(chatId);
+  if (ctx === undefined) {
+    throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Chat not found.');
+  }
+  if (ctx.chat.type === 'room') {
+    const membership = await isActiveRoomMember(chatId, userId);
+    if (membership === undefined) {
+      throw new MessageError(ErrorCodes.NOT_A_MEMBER, 403, 'You are not a member of this room.');
+    }
+    return ctx;
+  }
+  // Direct chat: caller must be one of the two participants, and DM
+  // eligibility rules (AC-DM-04 / AC-DM-06) must still hold.
+  const otherUserId = ctx.directParticipantIds?.find((id) => id !== userId);
+  if (
+    ctx.directParticipantIds === null ||
+    !ctx.directParticipantIds.includes(userId) ||
+    otherUserId === undefined
+  ) {
+    throw new MessageError(ErrorCodes.FORBIDDEN, 403, 'You are not a participant in this chat.');
+  }
+  if (await hasActiveBlockBetween(userId, otherUserId)) {
+    throw new MessageError(
+      ErrorCodes.DM_NOT_ALLOWED,
+      403,
+      'Direct messages are not allowed between these users.',
+    );
+  }
+  if (!(await hasActiveFriendship(userId, otherUserId))) {
+    throw new MessageError(
+      ErrorCodes.DM_NOT_ALLOWED,
+      403,
+      'Direct messages require an active friendship.',
+    );
+  }
+  return ctx;
+}
+
+export async function sendMessageToChat(input: {
+  chatId: string;
+  senderUserId: string;
+  bodyText: string;
+  replyToMessageId?: string | null;
+}): Promise<MessageRow> {
+  const body = validateBody(input.bodyText);
+  await requireChatWriteAccess(input.chatId, input.senderUserId);
+  if (input.replyToMessageId !== undefined && input.replyToMessageId !== null) {
+    const replyTarget = await findMessageById(input.replyToMessageId);
+    if (replyTarget === undefined || replyTarget.chatId !== input.chatId) {
+      throw new MessageError(
+        ErrorCodes.VALIDATION_ERROR,
+        400,
+        'Reply target must belong to the same chat.',
+        { field: 'replyToMessageId' },
+      );
+    }
+  }
+  const { message } = await insertMessageWithSequence({
+    chatId: input.chatId,
+    authorUserId: input.senderUserId,
+    bodyText: body,
+    replyToMessageId: input.replyToMessageId ?? null,
+  });
+  return message;
+}
+
+export async function sendDirectMessage(input: {
+  senderUserId: string;
+  recipientUserId: string;
+  bodyText: string;
+  replyToMessageId?: string | null;
+}): Promise<{
+  message: MessageRow;
+  chatId: string;
+  chatCreated: boolean;
+}> {
+  const body = validateBody(input.bodyText);
+  if (input.recipientUserId === input.senderUserId) {
+    throw new MessageError(ErrorCodes.VALIDATION_ERROR, 400, 'Cannot direct message yourself.', {
+      field: 'userId',
+    });
+  }
+  const recipient = await findUserActive(input.recipientUserId);
+  if (recipient === undefined) {
+    throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Recipient user not found.');
+  }
+  // AC-DM-04 / AC-DM-06: direct messaging requires an active friendship
+  // AND no block in either direction. Evaluate block first so a blocked
+  // pair can't probe for friendship status by message code.
+  if (await hasActiveBlockBetween(input.senderUserId, input.recipientUserId)) {
+    throw new MessageError(
+      ErrorCodes.DM_NOT_ALLOWED,
+      403,
+      'Direct messages are not allowed between these users.',
+    );
+  }
+  if (!(await hasActiveFriendship(input.senderUserId, input.recipientUserId))) {
+    throw new MessageError(
+      ErrorCodes.DM_NOT_ALLOWED,
+      403,
+      'Direct messages require an active friendship.',
+    );
+  }
+
+  if (input.replyToMessageId !== undefined && input.replyToMessageId !== null) {
+    // The reply-target must belong to the existing direct chat (if any)
+    // and the caller must already be a participant. A reply is never
+    // valid when the chat is about to be created for the first time.
+    const existing = await findDirectChatBetween(input.senderUserId, input.recipientUserId);
+    const replyTarget = await findMessageById(input.replyToMessageId);
+    if (existing === undefined || replyTarget === undefined || replyTarget.chatId !== existing.id) {
+      throw new MessageError(
+        ErrorCodes.VALIDATION_ERROR,
+        400,
+        'Reply target must belong to the same chat.',
+        { field: 'replyToMessageId' },
+      );
+    }
+  }
+
+  const result = await createDirectChatAndInsertMessage({
+    senderUserId: input.senderUserId,
+    recipientUserId: input.recipientUserId,
+    bodyText: body,
+    replyToMessageId: input.replyToMessageId ?? null,
+  });
+  return {
+    message: result.message,
+    chatId: result.chat.id,
+    chatCreated: result.chatCreated,
+  };
+}
+
+export async function editOwnMessage(input: {
+  messageId: string;
+  authorUserId: string;
+  bodyText: string;
+}): Promise<MessageRow> {
+  const body = validateBody(input.bodyText);
+  const existing = await findMessageById(input.messageId);
+  if (existing === undefined || existing.deletedAt !== null) {
+    throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Message not found.');
+  }
+  if (existing.authorUserId !== input.authorUserId) {
+    throw new MessageError(ErrorCodes.FORBIDDEN, 403, 'Only the author may edit this message.');
+  }
+  // Caller must still have write access to the containing chat (e.g.
+  // banned from the room, DM became frozen). Re-using the same gate as
+  // send keeps the rule in one place.
+  await requireChatWriteAccess(existing.chatId, input.authorUserId);
+  const updated = await updateMessageBody({
+    messageId: input.messageId,
+    authorUserId: input.authorUserId,
+    bodyText: body,
+  });
+  if (updated === undefined) {
+    // Another caller deleted the message between the lookup and the
+    // update. Surface the same 404 a cold caller would see.
+    throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Message not found.');
+  }
+  return updated;
+}
+
+export async function deleteMessage(input: {
+  messageId: string;
+  callerUserId: string;
+}): Promise<void> {
+  const existing = await findMessageById(input.messageId);
+  if (existing === undefined || existing.deletedAt !== null) {
+    throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Message not found.');
+  }
+  const ctx = await loadChatContext(existing.chatId);
+  if (ctx === undefined) {
+    throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Chat not found.');
+  }
+  const isAuthor = existing.authorUserId === input.callerUserId;
+  if (ctx.chat.type === 'room') {
+    const membership = await isActiveRoomMember(existing.chatId, input.callerUserId);
+    if (membership === undefined) {
+      throw new MessageError(ErrorCodes.NOT_A_MEMBER, 403, 'You are not a member of this room.');
+    }
+    const canModerate = membership.role === 'admin' || membership.role === 'owner';
+    if (!isAuthor && !canModerate) {
+      throw new MessageError(
+        ErrorCodes.FORBIDDEN,
+        403,
+        'Only the author, a room admin, or the owner may delete this message.',
+      );
+    }
+  } else {
+    // AC-MSG-06: direct chats have no admin role — participants can only
+    // delete their own messages.
+    if (
+      ctx.directParticipantIds === null ||
+      !ctx.directParticipantIds.includes(input.callerUserId)
+    ) {
+      throw new MessageError(ErrorCodes.FORBIDDEN, 403, 'You are not a participant in this chat.');
+    }
+    if (!isAuthor) {
+      throw new MessageError(ErrorCodes.FORBIDDEN, 403, 'Only the author may delete this message.');
+    }
+  }
+  const deleted = await softDeleteMessage({
+    messageId: input.messageId,
+    deletedByUserId: input.callerUserId,
+  });
+  if (deleted === undefined) {
+    throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Message not found.');
+  }
+}
+
+export async function fetchMessagesForChat(input: {
+  chatId: string;
+  callerUserId: string;
+  beforeSequence?: number | undefined;
+  afterSequence?: number | undefined;
+  limit?: number | undefined;
+}): Promise<{
+  chatId: string;
+  headSequence: number;
+  messages: MessagePublic[];
+}> {
+  const ctx = await loadChatContext(input.chatId);
+  if (ctx === undefined) {
+    throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Chat not found.');
+  }
+  // Read access mirrors write access: room membership OR direct-chat
+  // participation. DM history stays visible even if a block/unfriend
+  // froze the chat, per AC-DM-06. So we don't call the full
+  // write-access check here.
+  if (ctx.chat.type === 'room') {
+    if ((await isActiveRoomMember(input.chatId, input.callerUserId)) === undefined) {
+      throw new MessageError(ErrorCodes.NOT_A_MEMBER, 403, 'You are not a member of this room.');
+    }
+  } else {
+    if (
+      ctx.directParticipantIds === null ||
+      !ctx.directParticipantIds.includes(input.callerUserId)
+    ) {
+      throw new MessageError(ErrorCodes.FORBIDDEN, 403, 'You are not a participant in this chat.');
+    }
+  }
+  const limit = Math.min(
+    input.limit ?? PAGINATION_CURSOR_DEFAULT_LIMIT,
+    PAGINATION_CURSOR_MAX_LIMIT,
+  );
+  const rows = await listMessages({
+    chatId: input.chatId,
+    ...(input.beforeSequence !== undefined ? { beforeSequence: input.beforeSequence } : {}),
+    ...(input.afterSequence !== undefined ? { afterSequence: input.afterSequence } : {}),
+    limit,
+  });
+  return {
+    chatId: input.chatId,
+    headSequence: ctx.chat.currentSequence,
+    messages: rows.map(messageRowToPublic),
+  };
+}
+
+export async function advanceReadState(input: {
+  chatId: string;
+  userId: string;
+  readUpToSequence: number;
+}): Promise<{ chatId: string; lastReadSequence: number }> {
+  const ctx = await loadChatContext(input.chatId);
+  if (ctx === undefined) {
+    throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Chat not found.');
+  }
+  if (ctx.chat.type === 'room') {
+    if ((await isActiveRoomMember(input.chatId, input.userId)) === undefined) {
+      throw new MessageError(ErrorCodes.NOT_A_MEMBER, 403, 'You are not a member of this room.');
+    }
+  } else {
+    if (ctx.directParticipantIds === null || !ctx.directParticipantIds.includes(input.userId)) {
+      throw new MessageError(ErrorCodes.FORBIDDEN, 403, 'You are not a participant in this chat.');
+    }
+  }
+  const row = await upsertReadState({
+    chatId: input.chatId,
+    userId: input.userId,
+    readUpToSequence: input.readUpToSequence,
+  });
+  return { chatId: input.chatId, lastReadSequence: row.lastReadSequence };
+}
+
+export async function fetchReadState(input: { chatId: string; userId: string }): Promise<{
+  chatId: string;
+  lastReadSequence: number;
+  headSequence: number;
+  hasUnread: boolean;
+}> {
+  const ctx = await loadChatContext(input.chatId);
+  if (ctx === undefined) {
+    throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Chat not found.');
+  }
+  if (ctx.chat.type === 'room') {
+    if ((await isActiveRoomMember(input.chatId, input.userId)) === undefined) {
+      throw new MessageError(ErrorCodes.NOT_A_MEMBER, 403, 'You are not a member of this room.');
+    }
+  } else {
+    if (ctx.directParticipantIds === null || !ctx.directParticipantIds.includes(input.userId)) {
+      throw new MessageError(ErrorCodes.FORBIDDEN, 403, 'You are not a participant in this chat.');
+    }
+  }
+  const state = await getReadState({
+    chatId: input.chatId,
+    userId: input.userId,
+  });
+  if (state === undefined) {
+    throw new MessageError(ErrorCodes.NOT_FOUND, 404, 'Chat not found.');
+  }
+  return {
+    chatId: input.chatId,
+    lastReadSequence: state.lastReadSequence,
+    headSequence: state.headSequence,
+    hasUnread: state.headSequence > state.lastReadSequence,
+  };
+}
+
+export function messageRowToPublic(row: MessageRow): MessagePublic {
+  return {
+    id: row.id,
+    chatId: row.chatId,
+    sequence: row.sequence,
+    authorUserId: row.authorUserId,
+    kind: row.kind,
+    bodyText: row.deletedAt === null ? (row.bodyText ?? null) : null,
+    replyToMessageId: row.replyToMessageId ?? null,
+    createdAt: row.createdAt.toISOString(),
+    editedAt: row.editedAt?.toISOString() ?? null,
+    deletedAt: row.deletedAt?.toISOString() ?? null,
+  };
+}

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -3,6 +3,7 @@ import { authPlugin, authRoutes } from '../modules/auth/index.js';
 import { roomsRoutes } from '../modules/rooms/index.js';
 import { friendsRoutes } from '../modules/friends/index.js';
 import { blocksRoutes } from '../modules/blocks/index.js';
+import { messagesRoutes } from '../modules/messages/index.js';
 import { healthzRoute } from './healthz.js';
 import { testSeedRoute } from './test-seed.js';
 
@@ -14,4 +15,5 @@ export const registerRoutes: FastifyPluginAsyncTypebox = async (fastify) => {
   await fastify.register(roomsRoutes);
   await fastify.register(friendsRoutes);
   await fastify.register(blocksRoutes);
+  await fastify.register(messagesRoutes);
 };

--- a/apps/api/src/routes/test-seed.ts
+++ b/apps/api/src/routes/test-seed.ts
@@ -143,6 +143,37 @@ export const testSeedRoute: FastifyPluginAsyncTypebox = (fastify) => {
     },
   );
 
+  // Test-only inspector used by AC-DM-04 to prove that a rejected DM
+  // send leaves no chat row behind. Returns the count of direct chats
+  // that contain both users as active participants. Guarded by the
+  // NODE_ENV=test registration + the Dockerfile production-bundle grep,
+  // same as the other /__test/* routes.
+  fastify.get(
+    '/__test/direct-chat-count',
+    {
+      schema: {
+        querystring: Type.Object({
+          userA: Type.String({ format: 'uuid' }),
+          userB: Type.String({ format: 'uuid' }),
+        }),
+        response: {
+          200: Type.Object({ data: Type.Object({ count: Type.Integer() }) }),
+        },
+      },
+    },
+    async (req) => {
+      const rows = await pgSql<{ count: string | number }[]>`
+        SELECT COUNT(*)::int AS count
+        FROM chats c
+        JOIN direct_chat_participants a ON a.chat_id = c.id AND a.user_id = ${req.query.userA}
+        JOIN direct_chat_participants b ON b.chat_id = c.id AND b.user_id = ${req.query.userB}
+        WHERE c.type = 'direct' AND c.deleted_at IS NULL
+      `;
+      const count = Number(rows[0]?.count ?? 0);
+      return { data: { count } };
+    },
+  );
+
   // Test-only inspector that returns the latest raw password-reset token for
   // a given email. In real deployments the token travels via SMTP; until the
   // mail transport is wired up (not in WS-02 scope), this gated peek lets

--- a/apps/api/src/routes/test-seed.ts
+++ b/apps/api/src/routes/test-seed.ts
@@ -34,27 +34,31 @@ export const testSeedRoute: FastifyPluginAsyncTypebox = (fastify) => {
         );
       }
 
-      // Truncate every table WS-02+WS-03 has created so far. The
-      // `CASCADE` clause handles any FKs to these tables that later
-      // workstreams add. Order in the list is informational only —
-      // CASCADE does the real work.
-      await pgSql.unsafe(
-        `TRUNCATE TABLE
-           room_bans,
-           room_invitations,
-           room_memberships,
-           rooms,
-           direct_chat_participants,
-           chats,
-           friend_requests,
-           friendships,
-           user_blocks,
-           password_reset_tokens,
-           sessions,
-           users
-         RESTART IDENTITY CASCADE`,
-      );
-      clearTestResetTokens();
+      if (strategy === 'truncate') {
+        // Truncate every table WS-02+WS-03+WS-04 has created so far. The
+        // `CASCADE` clause handles any FKs to these tables that later
+        // workstreams add. Order in the list is informational only —
+        // CASCADE does the real work.
+        await pgSql.unsafe(
+          `TRUNCATE TABLE
+             chat_read_state,
+             messages,
+             room_bans,
+             room_invitations,
+             room_memberships,
+             rooms,
+             direct_chat_participants,
+             chats,
+             friend_requests,
+             friendships,
+             user_blocks,
+             password_reset_tokens,
+             sessions,
+             users
+           RESTART IDENTITY CASCADE`,
+        );
+        clearTestResetTokens();
+      }
 
       const userIds: Record<string, string> = {};
       for (const u of req.body.users ?? []) {
@@ -67,6 +71,64 @@ export const testSeedRoute: FastifyPluginAsyncTypebox = (fastify) => {
           passwordHash,
         });
         userIds[u.username] = row.id;
+      }
+
+      async function requireUserIdAsync(username: string): Promise<string> {
+        const cached = userIds[username];
+        if (cached !== undefined) return cached;
+        // In 'append' mode the caller may reference users seeded by an
+        // earlier call that we weren't asked to re-insert; look them up
+        // by canonical username.
+        if (strategy === 'append') {
+          const usernameCanonical = normalizeUsername(username);
+          const rows = await pgSql<{ id: string }[]>`
+            SELECT id FROM users WHERE username_canonical = ${usernameCanonical} LIMIT 1
+          `;
+          const row = rows[0];
+          if (row !== undefined) {
+            userIds[username] = row.id;
+            return row.id;
+          }
+        }
+        throw fastify.httpErrors.badRequest(`seed references unknown user: ${username}`);
+      }
+
+      // Friendships (WS-04 needs them for AC-DM-05; AC-DM-02 isn't in the
+      // HTTP surface yet, so the test seed is the only writer). The
+      // fixture accepts any pair order and reorders to satisfy the
+      // `user_low_id < user_high_id` CHECK constraint from migration 0003.
+      for (const f of req.body.friendships ?? []) {
+        const aId = await requireUserIdAsync(f.userA);
+        const bId = await requireUserIdAsync(f.userB);
+        const [low, high] = aId < bId ? [aId, bId] : [bId, aId];
+        await pgSql`
+          INSERT INTO friendships (user_low_id, user_high_id)
+          VALUES (${low}, ${high})
+          ON CONFLICT DO NOTHING
+        `;
+      }
+
+      // Room memberships by chat id — lets a spec promote a second user
+      // to `admin` for moderation tests without going through the join
+      // endpoint (which WS-03 hasn't landed yet).
+      for (const m of req.body.roomMembershipsByChatId ?? []) {
+        const memberId = await requireUserIdAsync(m.username);
+        await pgSql`
+          INSERT INTO room_memberships (room_chat_id, user_id, role)
+          VALUES (${m.chatId}, ${memberId}, ${m.role})
+          ON CONFLICT DO NOTHING
+        `;
+      }
+
+      // User blocks (WS-04 needs them for the AC-DM-04 rejection path).
+      for (const b of req.body.blocks ?? []) {
+        const blockerId = await requireUserIdAsync(b.blocker);
+        const blockedId = await requireUserIdAsync(b.blocked);
+        await pgSql`
+          INSERT INTO user_blocks (blocker_user_id, blocked_user_id)
+          VALUES (${blockerId}, ${blockedId})
+          ON CONFLICT DO NOTHING
+        `;
       }
 
       return {

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -372,7 +372,7 @@ Represents room-level ban status.
 
 ## 4.13 Message
 
-Persistent chat message.
+Persistent chat message. Landed by WS-04 in migration `0004_ws04_messaging.sql`; the schema matches this section verbatim (bigint `sequence`, `(chat_id, sequence)` unique, `kind` enum default `text`, reply FK `ON DELETE SET NULL`, nullable edit/delete audit columns).
 
 ### Fields
 
@@ -460,7 +460,7 @@ Attachment metadata. Binary lives on filesystem.
 
 ## 4.16 ChatReadState
 
-Per-user read position per chat. A row is created lazily on first read-state advancement; absence of a row means the user has never opened this chat.
+Per-user read position per chat. A row is created lazily on first read-state advancement; absence of a row means the user has never opened this chat. Landed by WS-04 in migration `0004_ws04_messaging.sql`: composite PK `(chat_id, user_id)`, `last_read_sequence BIGINT NOT NULL DEFAULT 0` with a `>= 0` CHECK, and a `(user_id, updated_at DESC)` index for cross-chat read-state queries.
 
 ### Fields
 

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -1,4 +1,5 @@
 # Traceability Index
+
 ## Online Chat Server
 
 ## 1. Purpose
@@ -8,6 +9,7 @@ This document is the single source of truth for mapping **acceptance criteria** 
 Every AC in `acceptance-criteria-pack.md` must appear here. Every API endpoint in `api-and-events.md` must be cited by at least one AC row. Every state-model transition in `state-model.md` that has business-visible effects must be reachable from at least one AC row.
 
 This table is checked by CI (`docs/ci-pipeline.md` → `doc-consistency.yml`):
+
 - Every `AC-*` ID mentioned in this table MUST exist in `acceptance-criteria-pack.md`.
 - Every row's "Playwright test" column MUST correspond to a test file whose name starts with the AC ID.
 - Every API path mentioned MUST exist in `api-and-events.md`.
@@ -31,9 +33,9 @@ This table is checked by CI (`docs/ci-pipeline.md` → `doc-consistency.yml`):
 
 ## 3.1 Bootstrap (pseudo-AC)
 
-| AC ID | Capability | HTTP | WS event | State transition | Entities | Permissions row | Playwright test |
-|---|---|---|---|---|---|---|---|
-| AC-BOOT-00 | Stage-0 scaffolding and bootstrap | `GET /healthz`, `POST /__test/seed` (dev) | — | — | — (no persistent entities) | — | `AC-BOOT-00-bootstrap.spec.ts` |
+| AC ID      | Capability                        | HTTP                                      | WS event | State transition | Entities                   | Permissions row | Playwright test                |
+| ---------- | --------------------------------- | ----------------------------------------- | -------- | ---------------- | -------------------------- | --------------- | ------------------------------ |
+| AC-BOOT-00 | Stage-0 scaffolding and bootstrap | `GET /healthz`, `POST /__test/seed` (dev) | —        | —                | — (no persistent entities) | —               | `AC-BOOT-00-bootstrap.spec.ts` |
 
 ## 3.2 Stage-1 tooling (meta safety net)
 
@@ -42,34 +44,35 @@ that implement them. Not ACs — they have no Playwright spec, no permissions
 row, and no API surface. Listed here so every script under `scripts/` can
 be traced back to the issue that motivated it.
 
-| Issue | Script | Layer | Invoked from | Closed in |
-|---|---|---|---|---|
-| [#1](https://github.com/electronicostrich/online-chat-server/issues/1) | `scripts/doc-coverage.ts` | 3 (CI) | `pnpm doc-consistency`, lefthook `pre-push`, `.github/workflows/ci.yml doc-consistency` | `chore: implement #1 doc-coverage.ts` |
-| [#2](https://github.com/electronicostrich/online-chat-server/issues/2) | `scripts/schema-drift-check.ts` | 3 (CI) | `pnpm schema-drift`, `.github/workflows/ci.yml schema-drift` | `chore: implement #2 schema-drift-check.ts` |
-| [#3](https://github.com/electronicostrich/online-chat-server/issues/3) | `scripts/lint-compose.ts` | 2/3 | `pnpm lint-compose` | `chore: implement #3 lint-compose.ts` |
-| [#4](https://github.com/electronicostrich/online-chat-server/issues/4) | `scripts/check-test-substance.ts` | 3 (CI) | CI (planned); ad-hoc local | `chore: implement #4 check-test-substance.ts` |
-| [#5](https://github.com/electronicostrich/online-chat-server/issues/5) | `scripts/check-pr-description.ts` | 3 (CI) | `.github/workflows/ci.yml check-pr-title` and `check-pr-description` | `chore: implement #5 check-pr-description.ts` |
-| [#6](https://github.com/electronicostrich/online-chat-server/issues/6) | `scripts/check-suppressions.ts` | 2 (pre-commit) / 3 (CI) | lefthook `pre-commit suppression-check`; CI base↔head mode | `chore: implement #6 check-suppressions.ts` |
-| [#7](https://github.com/electronicostrich/online-chat-server/issues/7) | `scripts/drizzle-guard.ts` | 2 (pre-commit) | lefthook `pre-commit drizzle-guard` | `chore: implement #7 drizzle-guard.ts` |
-| [#8](https://github.com/electronicostrich/online-chat-server/issues/8) | `scripts/ac-test-presence.ts` | 2 (pre-commit) | lefthook `pre-commit ac-test-presence` | `chore: implement #8 ac-test-presence.ts` |
+| Issue                                                                  | Script                            | Layer                   | Invoked from                                                                            | Closed in                                     |
+| ---------------------------------------------------------------------- | --------------------------------- | ----------------------- | --------------------------------------------------------------------------------------- | --------------------------------------------- |
+| [#1](https://github.com/electronicostrich/online-chat-server/issues/1) | `scripts/doc-coverage.ts`         | 3 (CI)                  | `pnpm doc-consistency`, lefthook `pre-push`, `.github/workflows/ci.yml doc-consistency` | `chore: implement #1 doc-coverage.ts`         |
+| [#2](https://github.com/electronicostrich/online-chat-server/issues/2) | `scripts/schema-drift-check.ts`   | 3 (CI)                  | `pnpm schema-drift`, `.github/workflows/ci.yml schema-drift`                            | `chore: implement #2 schema-drift-check.ts`   |
+| [#3](https://github.com/electronicostrich/online-chat-server/issues/3) | `scripts/lint-compose.ts`         | 2/3                     | `pnpm lint-compose`                                                                     | `chore: implement #3 lint-compose.ts`         |
+| [#4](https://github.com/electronicostrich/online-chat-server/issues/4) | `scripts/check-test-substance.ts` | 3 (CI)                  | CI (planned); ad-hoc local                                                              | `chore: implement #4 check-test-substance.ts` |
+| [#5](https://github.com/electronicostrich/online-chat-server/issues/5) | `scripts/check-pr-description.ts` | 3 (CI)                  | `.github/workflows/ci.yml check-pr-title` and `check-pr-description`                    | `chore: implement #5 check-pr-description.ts` |
+| [#6](https://github.com/electronicostrich/online-chat-server/issues/6) | `scripts/check-suppressions.ts`   | 2 (pre-commit) / 3 (CI) | lefthook `pre-commit suppression-check`; CI base↔head mode                              | `chore: implement #6 check-suppressions.ts`   |
+| [#7](https://github.com/electronicostrich/online-chat-server/issues/7) | `scripts/drizzle-guard.ts`        | 2 (pre-commit)          | lefthook `pre-commit drizzle-guard`                                                     | `chore: implement #7 drizzle-guard.ts`        |
+| [#8](https://github.com/electronicostrich/online-chat-server/issues/8) | `scripts/ac-test-presence.ts`     | 2 (pre-commit)          | lefthook `pre-commit ac-test-presence`                                                  | `chore: implement #8 ac-test-presence.ts`     |
 
 ## 4. Authentication, sessions, and account lifecycle
 
-| AC ID | Capability | HTTP | WS event | State transition | Entities | Permissions row | Playwright test |
-|---|---|---|---|---|---|---|---|
-| AC-AUTH-01 | Registration with unique creds | `POST /auth/register` | — | User: none → active | User | §3 "Register account" | `AC-AUTH-01-registration.spec.ts` |
-| AC-AUTH-02 | Registration fails on duplicate | `POST /auth/register` | — | — | User | §3 "Register account" | `AC-AUTH-02-duplicate-registration.spec.ts` |
-| AC-AUTH-03 | Login creates one session | `POST /auth/login` | — | Session: none → active | User, Session | §3 "Sign in" | `AC-AUTH-03-login-session.spec.ts` |
-| AC-AUTH-04 | Logout revokes only current | `POST /auth/logout` | `session.revoked` (self) | Session: active → revoked | Session | §3 "Sign out current session" | `AC-AUTH-04-logout-scope.spec.ts` |
-| AC-AUTH-05 | Sessions screen is accurate | `GET /sessions` | — | — | Session | §3 "View active sessions" | `AC-AUTH-05-sessions-list.spec.ts` |
-| AC-AUTH-06 | Session revocation is immediate | `POST /auth/logout-session` | `session.revoked` (target) | Session: active → revoked | Session | §3 "Revoke another active session" | `AC-AUTH-06-revoke-immediate.spec.ts` |
-| AC-AUTH-07 | Password change | `POST /auth/password-change` (see note) | — | — | User | §3 "Change password" | `AC-AUTH-07-password-change.spec.ts` |
-| AC-AUTH-08 | Password reset flow | `POST /auth/password-reset/request`, `POST /auth/password-reset/confirm` | — | PasswordResetToken: open → consumed | PasswordResetToken, User | §3 "Request password reset" | `AC-AUTH-08-password-reset.spec.ts` |
-| AC-AUTH-09 | Account deletion cascades | `DELETE /users/me` (see note) | `session.revoked` × N | User: active → deleted; owned Rooms deleted | User, Room, Chat, Message, Attachment, RoomMembership | §3 "Delete own account" | `AC-AUTH-09-account-deletion.spec.ts` |
+| AC ID      | Capability                      | HTTP                                                                     | WS event                   | State transition                            | Entities                                              | Permissions row                    | Playwright test                             |
+| ---------- | ------------------------------- | ------------------------------------------------------------------------ | -------------------------- | ------------------------------------------- | ----------------------------------------------------- | ---------------------------------- | ------------------------------------------- |
+| AC-AUTH-01 | Registration with unique creds  | `POST /auth/register`                                                    | —                          | User: none → active                         | User                                                  | §3 "Register account"              | `AC-AUTH-01-registration.spec.ts`           |
+| AC-AUTH-02 | Registration fails on duplicate | `POST /auth/register`                                                    | —                          | —                                           | User                                                  | §3 "Register account"              | `AC-AUTH-02-duplicate-registration.spec.ts` |
+| AC-AUTH-03 | Login creates one session       | `POST /auth/login`                                                       | —                          | Session: none → active                      | User, Session                                         | §3 "Sign in"                       | `AC-AUTH-03-login-session.spec.ts`          |
+| AC-AUTH-04 | Logout revokes only current     | `POST /auth/logout`                                                      | `session.revoked` (self)   | Session: active → revoked                   | Session                                               | §3 "Sign out current session"      | `AC-AUTH-04-logout-scope.spec.ts`           |
+| AC-AUTH-05 | Sessions screen is accurate     | `GET /sessions`                                                          | —                          | —                                           | Session                                               | §3 "View active sessions"          | `AC-AUTH-05-sessions-list.spec.ts`          |
+| AC-AUTH-06 | Session revocation is immediate | `POST /auth/logout-session`                                              | `session.revoked` (target) | Session: active → revoked                   | Session                                               | §3 "Revoke another active session" | `AC-AUTH-06-revoke-immediate.spec.ts`       |
+| AC-AUTH-07 | Password change                 | `POST /auth/password-change` (see note)                                  | —                          | —                                           | User                                                  | §3 "Change password"               | `AC-AUTH-07-password-change.spec.ts`        |
+| AC-AUTH-08 | Password reset flow             | `POST /auth/password-reset/request`, `POST /auth/password-reset/confirm` | —                          | PasswordResetToken: open → consumed         | PasswordResetToken, User                              | §3 "Request password reset"        | `AC-AUTH-08-password-reset.spec.ts`         |
+| AC-AUTH-09 | Account deletion cascades       | `DELETE /users/me` (see note)                                            | `session.revoked` × N      | User: active → deleted; owned Rooms deleted | User, Room, Chat, Message, Attachment, RoomMembership | §3 "Delete own account"            | `AC-AUTH-09-account-deletion.spec.ts`       |
 
 Notes: `POST /auth/password-change` is now documented in `api-and-events.md` §5.1 (landed with WS-02 AC-AUTH-07). `DELETE /users/me` is still documented there but not yet implemented — AC-AUTH-09 is held for WS-03, see `docs/workstream-notes/ws-02-blockers.md`.
 
 Implementation status (WS-02 autorun, 2026-04-19):
+
 - AC-AUTH-01 — implemented. `POST /auth/register` issues Argon2id-hashed password, opaque session cookie (`chat_sid`, httpOnly), CSRF token cookie (`csrf_token`, double-submit). Spec at `e2e/specs/AC-AUTH-01-registration.spec.ts`.
 - AC-AUTH-02 — implemented. Duplicate email and duplicate username (including case-insensitive collisions) return `CONFLICT` with `details.field`. Spec at `e2e/specs/AC-AUTH-02-duplicate-registration.spec.ts`.
 - AC-AUTH-03 — implemented. `POST /auth/login` issues a per-browser session without touching other sessions; wrong password returns `UNAUTHENTICATED` with no cookies. Spec at `e2e/specs/AC-AUTH-03-login-session.spec.ts`.
@@ -82,6 +85,7 @@ Implementation status (WS-02 autorun, 2026-04-19):
 - AC-AUTH-09 — **deferred** to a follow-up PR. The account-deletion cascade covers rooms, memberships, friendships, blocks, friend requests, and user blocks — all of which are WS-03-owned entities that don't exist in the schema yet. See `docs/workstream-notes/ws-02-blockers.md` for the full rationale and hand-off notes.
 
 Implementation status (WS-03 autorun, 2026-04-19):
+
 - AC-ROOM-01 — implemented. `POST /rooms` creates a `chats` row (type=`room`), a `rooms` row (with case-insensitive `normalized_name` uniqueness), and an owner `room_memberships` row in one transaction. Spec at `e2e/specs/AC-ROOM-01-create-room.spec.ts`.
 - AC-ROOM-02 — covered by the same `POST /rooms` handler via the normalized-name unique index; the duplicate-name assertion lives inside `e2e/specs/AC-ROOM-01-create-room.spec.ts`. The dedicated spec file named in the table row above (`AC-ROOM-02-name-uniqueness.spec.ts`) is authored by the follow-up that also lands the `PATCH /rooms/{id}` rename path — the row's file reference is the target, not the current state.
 - AC-ROOM-08 — implemented (HTTP layer). `DELETE /rooms/{id}` is owner-only, soft-deletes both the `rooms` row (`deleted_at`) and the underlying `chats` row so messages/attachments become unreachable to WS-04/WS-06. Hard-purge after 30 days is a scheduled job held for WS-08. Spec at `e2e/specs/AC-ROOM-08-room-deletion.spec.ts`.
@@ -89,118 +93,136 @@ Implementation status (WS-03 autorun, 2026-04-19):
 - AC-DM-06 — partially implemented. `POST /blocks/{userId}` creates the `user_blocks` row, is idempotent, and rejects self-block. The WS-03 slice of the freeze semantics (block rejects friend requests in either direction) is proven in `e2e/specs/AC-DM-06-block-freezes-dm.spec.ts`. Freezing an existing direct chat's message-send path belongs to WS-04's `POST /chats/{id}/messages` handler and is held for that workstream.
 - **Deferred** within WS-03: AC-ROOM-03..07, AC-INV-01..04, AC-MOD-01..08, AC-DM-02..05. See `docs/workstream-notes/ws-03-progress.md` for the full list and rationale.
 
+Implementation status (WS-04 autorun, 2026-04-19):
+
+- AC-MSG-01 — implemented. `POST /chats/{chatId}/messages` accepts plain text, multiline text, UTF-8 emoji, and optional `replyToMessageId`. Room-membership gate enforces authorization; reply targets must belong to the same chat. Spec at `e2e/specs/AC-MSG-01-content-forms.spec.ts`.
+- AC-MSG-02 — implemented. The send path measures `bodyText` UTF-8 byte length and rejects any payload over 3 KB with `VALIDATION_ERROR`. Emoji/multibyte cases are covered in the spec. Spec at `e2e/specs/AC-MSG-02-size-limit.spec.ts`.
+- AC-MSG-03 — implemented. `GET /chats/{chatId}/messages` returns DESC-by-`sequence` rows; the Playwright spec asserts `createdAt` monotonicity and body-text ordering for a contiguous batch. Spec at `e2e/specs/AC-MSG-03-ordering.spec.ts`.
+- AC-MSG-04 — implemented. `PATCH /messages/{messageId}` requires `req.session.user.id === message.author_user_id`; sets `edited_at`. Non-authors get `FORBIDDEN`. Spec at `e2e/specs/AC-MSG-04-edit-own.spec.ts`.
+- AC-MSG-05 — implemented. `DELETE /messages/{messageId}` grants moderation rights to the room's admin and owner; other members are `FORBIDDEN`. Deleted messages stay in history with `body_text` nulled out so the sequence space isn't reshuffled. Spec at `e2e/specs/AC-MSG-05-admin-delete.spec.ts`.
+- AC-MSG-06 — implemented. Direct-chat participants can only delete their own messages; the non-author case returns `FORBIDDEN`. Spec at `e2e/specs/AC-MSG-06-dm-delete-restricted.spec.ts`.
+- AC-MSG-07 — implemented (HTTP layer). `GET /chats/{chatId}/messages?afterSequence=N` returns the missed window from durable history. The websocket re-subscribe that integrates this is WS-05's responsibility. Spec at `e2e/specs/AC-MSG-07-offline-catchup.spec.ts`.
+- AC-MSG-08 — implemented. `beforeSequence` + `limit` pages older-than-cursor windows; non-overlapping pages confirmed in the spec. Spec at `e2e/specs/AC-MSG-08-infinite-scroll.spec.ts`.
+- AC-RT-03 — implemented. `insertMessageWithSequence` bumps `chats.current_sequence` and inserts the message inside one transaction, so concurrent sends produce contiguous sequence numbers with no duplicates. Spec at `e2e/specs/AC-RT-03-sequence-allocation.spec.ts`.
+- AC-DM-04 — implemented. Send paths (chat-scoped and `POST /dm/{userId}/messages`) check `findActiveBlockBetween` before `hasActiveFriendship`; both rejection paths return `DM_NOT_ALLOWED`. The WS-03 friendship-writer is still deferred, so the Playwright spec uses the `/__test/seed` fixture's new `friendships` + `blocks` fields. Spec at `e2e/specs/AC-DM-04-dm-eligibility.spec.ts`.
+- AC-DM-05 — implemented. `POST /dm/{userId}/messages` lazy-creates the direct chat + participant rows in a single transaction the first time, and reuses the existing chat thereafter. Response reports `chat.created=true/false`. Spec at `e2e/specs/AC-DM-05-first-dm.spec.ts`.
+- AC-UNREAD-01 — implemented. `GET /chats/{chatId}/read-state` returns `hasUnread = headSequence > lastReadSequence`; absence of a `chat_read_state` row is treated as `last_read_sequence=0`. Spec at `e2e/specs/AC-UNREAD-01-room-indicator.spec.ts`.
+- AC-UNREAD-02 — implemented. Direct-chat flavour of the same contract, proven on a lazy-created DM. Spec at `e2e/specs/AC-UNREAD-02-dm-indicator.spec.ts`.
+- AC-UNREAD-03 — implemented. `POST /chats/{chatId}/read` upserts `chat_read_state` with `GREATEST(existing, LEAST(requested, head))` — advances are monotonic and over-advances silently clamp. Spec at `e2e/specs/AC-UNREAD-03-explicit-advance.spec.ts`.
+- **Deferred** within WS-04: AC-UNREAD-04 (multi-tab consistency needs WS-05's websocket fan-out), the `message.created/edited/deleted/readstate.updated` event emissions (all WS-05), and the gap-detection `sync.request` contract (AC-RT-04; ends up in WS-05 on top of this history layer).
+
 ## 5. Presence
 
-| AC ID | Capability | HTTP | WS event | State transition | Entities | Permissions row | Playwright test |
-|---|---|---|---|---|---|---|---|
-| AC-PRES-01 | Online if any tab active | — | `presence.updated` | Presence: → online | LiveConnection, PresenceAggregate | §4 "View presence of friend" | `AC-PRES-01-multitab-online.spec.ts` |
-| AC-PRES-02 | AFK when all tabs idle >60s | — | `presence.updated` | Presence: online → afk | LiveConnection, PresenceAggregate | §4 | `AC-PRES-02-afk-threshold.spec.ts` |
-| AC-PRES-03 | Offline when no live tabs | — | `presence.updated` | Presence: afk/online → offline | LiveConnection | §4 | `AC-PRES-03-offline-no-tabs.spec.ts` |
-| AC-PRES-04 | Hibernated tab eventually offline | — | `presence.updated` | Presence: → offline after 45s stale | LiveConnection | §4 | `AC-PRES-04-hibernation.spec.ts` |
-| AC-PRES-05 | No inactivity logout | — | — | Session stays active | Session | §3 "Sign out current session" | `AC-PRES-05-no-inactivity-logout.spec.ts` |
+| AC ID      | Capability                        | HTTP | WS event           | State transition                    | Entities                          | Permissions row               | Playwright test                           |
+| ---------- | --------------------------------- | ---- | ------------------ | ----------------------------------- | --------------------------------- | ----------------------------- | ----------------------------------------- |
+| AC-PRES-01 | Online if any tab active          | —    | `presence.updated` | Presence: → online                  | LiveConnection, PresenceAggregate | §4 "View presence of friend"  | `AC-PRES-01-multitab-online.spec.ts`      |
+| AC-PRES-02 | AFK when all tabs idle >60s       | —    | `presence.updated` | Presence: online → afk              | LiveConnection, PresenceAggregate | §4                            | `AC-PRES-02-afk-threshold.spec.ts`        |
+| AC-PRES-03 | Offline when no live tabs         | —    | `presence.updated` | Presence: afk/online → offline      | LiveConnection                    | §4                            | `AC-PRES-03-offline-no-tabs.spec.ts`      |
+| AC-PRES-04 | Hibernated tab eventually offline | —    | `presence.updated` | Presence: → offline after 45s stale | LiveConnection                    | §4                            | `AC-PRES-04-hibernation.spec.ts`          |
+| AC-PRES-05 | No inactivity logout              | —    | —                  | Session stays active                | Session                           | §3 "Sign out current session" | `AC-PRES-05-no-inactivity-logout.spec.ts` |
 
 ## 6. Friends, blocks, and direct messaging
 
-| AC ID | Capability | HTTP | WS event | State transition | Entities | Permissions row | Playwright test |
-|---|---|---|---|---|---|---|---|
-| AC-DM-01 | Friend request | `POST /friends/requests` | — | FriendRequest: none → open | FriendRequest | §4 "Send friend request" | `AC-DM-01-friend-request.spec.ts` |
-| AC-DM-02 | Friendship on acceptance | `POST /friends/requests/{id}/accept` | — | FriendRequest: open → accepted; Friendship: none → active | FriendRequest, Friendship | §4 "Accept friend request" | `AC-DM-02-friendship-accept.spec.ts` |
-| AC-DM-03 | Friend removal freezes DM | `DELETE /friends/{userId}` | — | Friendship: active → removed; DirectChat: active → frozen | Friendship, Chat (direct) | §4 "Remove friend" | `AC-DM-03-friend-removal-freeze.spec.ts` |
-| AC-DM-04 | DM requires friendship + no block | `POST /chats/{chatId}/messages` (rejected) | — | — | Friendship, UserBlock | §5 "Send message in existing direct chat" | `AC-DM-04-dm-eligibility.spec.ts` |
-| AC-DM-05 | First DM creates direct chat | `POST /chats/{chatId}/messages` (first) OR `POST /dm/{userId}/messages` (see note) | `message.created` | Chat: none → active; DirectChatParticipant × 2 created | Chat, DirectChatParticipant, Message | §5 "Create direct chat by sending first message" | `AC-DM-05-first-dm.spec.ts` |
-| AC-DM-06 | Block freezes DM | `POST /blocks/{userId}` | — | UserBlock: none → active; DirectChat: active → frozen | UserBlock, Chat | §4 "Block another user" | `AC-DM-06-block-freezes-dm.spec.ts` |
+| AC ID    | Capability                        | HTTP                                                                               | WS event          | State transition                                          | Entities                             | Permissions row                                  | Playwright test                          |
+| -------- | --------------------------------- | ---------------------------------------------------------------------------------- | ----------------- | --------------------------------------------------------- | ------------------------------------ | ------------------------------------------------ | ---------------------------------------- |
+| AC-DM-01 | Friend request                    | `POST /friends/requests`                                                           | —                 | FriendRequest: none → open                                | FriendRequest                        | §4 "Send friend request"                         | `AC-DM-01-friend-request.spec.ts`        |
+| AC-DM-02 | Friendship on acceptance          | `POST /friends/requests/{id}/accept`                                               | —                 | FriendRequest: open → accepted; Friendship: none → active | FriendRequest, Friendship            | §4 "Accept friend request"                       | `AC-DM-02-friendship-accept.spec.ts`     |
+| AC-DM-03 | Friend removal freezes DM         | `DELETE /friends/{userId}`                                                         | —                 | Friendship: active → removed; DirectChat: active → frozen | Friendship, Chat (direct)            | §4 "Remove friend"                               | `AC-DM-03-friend-removal-freeze.spec.ts` |
+| AC-DM-04 | DM requires friendship + no block | `POST /chats/{chatId}/messages` (rejected)                                         | —                 | —                                                         | Friendship, UserBlock                | §5 "Send message in existing direct chat"        | `AC-DM-04-dm-eligibility.spec.ts`        |
+| AC-DM-05 | First DM creates direct chat      | `POST /chats/{chatId}/messages` (first) OR `POST /dm/{userId}/messages` (see note) | `message.created` | Chat: none → active; DirectChatParticipant × 2 created    | Chat, DirectChatParticipant, Message | §5 "Create direct chat by sending first message" | `AC-DM-05-first-dm.spec.ts`              |
+| AC-DM-06 | Block freezes DM                  | `POST /blocks/{userId}`                                                            | —                 | UserBlock: none → active; DirectChat: active → frozen     | UserBlock, Chat                      | §4 "Block another user"                          | `AC-DM-06-block-freezes-dm.spec.ts`      |
 
 Note: A dedicated `POST /dm/{userId}/messages` endpoint for DM creation is not yet in `api-and-events.md`. The current model uses `POST /chats/{chatId}/messages` which requires a chatId; the DM-creation flow needs a resolution (lazy-create on first message OR explicit `POST /dm/{userId}` endpoint). Resolve before AC-DM-05 implementation.
 
 ## 7. Rooms
 
-| AC ID | Capability | HTTP | WS event | State transition | Entities | Permissions row | Playwright test |
-|---|---|---|---|---|---|---|---|
-| AC-ROOM-01 | Authenticated user creates room | `POST /rooms` | — | Room: none → active; RoomMembership (owner) | Room, Chat, RoomMembership | §6 "Create room" | `AC-ROOM-01-create-room.spec.ts` |
-| AC-ROOM-02 | Room names globally unique | `POST /rooms`, `PATCH /rooms/{id}` | — | — (rejected) | Room | §6 "Change room name" | `AC-ROOM-02-name-uniqueness.spec.ts` |
-| AC-ROOM-03 | Public catalog searchable | `GET /rooms/public` | — | — | Room | §6 "View public room catalog" | `AC-ROOM-03-public-catalog.spec.ts` |
-| AC-ROOM-04 | Private rooms hidden | `GET /rooms/public` | — | — | Room | §6 "View private room in public catalog" | `AC-ROOM-04-private-hidden.spec.ts` |
-| AC-ROOM-05 | Public room joinable unless banned | `POST /rooms/{id}/join` | `room.membership.updated` | RoomMembership: none → active | RoomMembership | §6 "Join public room" | `AC-ROOM-05-public-join.spec.ts` |
-| AC-ROOM-06 | Banned users cannot join | `POST /rooms/{id}/join` (rejected) | — | — | RoomBan | §6 "Join public room" | `AC-ROOM-06-banned-cannot-join.spec.ts` |
-| AC-ROOM-07 | Owner cannot leave | `POST /rooms/{id}/leave` (rejected) | — | — | RoomMembership | §6 "Leave room" | `AC-ROOM-07-owner-cannot-leave.spec.ts` |
-| AC-ROOM-08 | Room deletion removes content | `DELETE /rooms/{id}` | `room.membership.updated` × N | Chat: active → deleted (soft, 30d then hard) | Room, Chat, Message, Attachment, RoomMembership | §6 "Delete room" | `AC-ROOM-08-room-deletion.spec.ts` |
+| AC ID      | Capability                         | HTTP                                | WS event                      | State transition                             | Entities                                        | Permissions row                          | Playwright test                         |
+| ---------- | ---------------------------------- | ----------------------------------- | ----------------------------- | -------------------------------------------- | ----------------------------------------------- | ---------------------------------------- | --------------------------------------- |
+| AC-ROOM-01 | Authenticated user creates room    | `POST /rooms`                       | —                             | Room: none → active; RoomMembership (owner)  | Room, Chat, RoomMembership                      | §6 "Create room"                         | `AC-ROOM-01-create-room.spec.ts`        |
+| AC-ROOM-02 | Room names globally unique         | `POST /rooms`, `PATCH /rooms/{id}`  | —                             | — (rejected)                                 | Room                                            | §6 "Change room name"                    | `AC-ROOM-02-name-uniqueness.spec.ts`    |
+| AC-ROOM-03 | Public catalog searchable          | `GET /rooms/public`                 | —                             | —                                            | Room                                            | §6 "View public room catalog"            | `AC-ROOM-03-public-catalog.spec.ts`     |
+| AC-ROOM-04 | Private rooms hidden               | `GET /rooms/public`                 | —                             | —                                            | Room                                            | §6 "View private room in public catalog" | `AC-ROOM-04-private-hidden.spec.ts`     |
+| AC-ROOM-05 | Public room joinable unless banned | `POST /rooms/{id}/join`             | `room.membership.updated`     | RoomMembership: none → active                | RoomMembership                                  | §6 "Join public room"                    | `AC-ROOM-05-public-join.spec.ts`        |
+| AC-ROOM-06 | Banned users cannot join           | `POST /rooms/{id}/join` (rejected)  | —                             | —                                            | RoomBan                                         | §6 "Join public room"                    | `AC-ROOM-06-banned-cannot-join.spec.ts` |
+| AC-ROOM-07 | Owner cannot leave                 | `POST /rooms/{id}/leave` (rejected) | —                             | —                                            | RoomMembership                                  | §6 "Leave room"                          | `AC-ROOM-07-owner-cannot-leave.spec.ts` |
+| AC-ROOM-08 | Room deletion removes content      | `DELETE /rooms/{id}`                | `room.membership.updated` × N | Chat: active → deleted (soft, 30d then hard) | Room, Chat, Message, Attachment, RoomMembership | §6 "Delete room"                         | `AC-ROOM-08-room-deletion.spec.ts`      |
 
 ## 8. Invitations
 
-| AC ID | Capability | HTTP | WS event | State transition | Entities | Permissions row | Playwright test |
-|---|---|---|---|---|---|---|---|
-| AC-INV-01 | Only registered users invited | `POST /rooms/{id}/invitations` | — | RoomInvitation: none → open | RoomInvitation | §7 "Invite registered user" | `AC-INV-01-registered-only.spec.ts` |
-| AC-INV-02 | Accept grants membership | `POST /rooms/{id}/invitations/{id}/accept` | `room.invitation.created` (consumed), `room.membership.updated` | RoomInvitation: open → accepted; RoomMembership: none → active | RoomInvitation, RoomMembership | §7 "Accept private-room invitation" | `AC-INV-02-accept-invite.spec.ts` |
-| AC-INV-03 | Reject changes nothing else | `POST /rooms/{id}/invitations/{id}/reject` | — | RoomInvitation: open → rejected | RoomInvitation | §7 "Reject private-room invitation" | `AC-INV-03-reject-invite.spec.ts` |
-| AC-INV-04 | Banned user cannot consume invite | `POST /rooms/{id}/invitations/{id}/accept` (rejected) | — | — | RoomInvitation, RoomBan | §7 "Accept private-room invitation" | `AC-INV-04-banned-invite.spec.ts` |
+| AC ID     | Capability                        | HTTP                                                  | WS event                                                        | State transition                                               | Entities                       | Permissions row                     | Playwright test                     |
+| --------- | --------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------ | ----------------------------------- | ----------------------------------- |
+| AC-INV-01 | Only registered users invited     | `POST /rooms/{id}/invitations`                        | —                                                               | RoomInvitation: none → open                                    | RoomInvitation                 | §7 "Invite registered user"         | `AC-INV-01-registered-only.spec.ts` |
+| AC-INV-02 | Accept grants membership          | `POST /rooms/{id}/invitations/{id}/accept`            | `room.invitation.created` (consumed), `room.membership.updated` | RoomInvitation: open → accepted; RoomMembership: none → active | RoomInvitation, RoomMembership | §7 "Accept private-room invitation" | `AC-INV-02-accept-invite.spec.ts`   |
+| AC-INV-03 | Reject changes nothing else       | `POST /rooms/{id}/invitations/{id}/reject`            | —                                                               | RoomInvitation: open → rejected                                | RoomInvitation                 | §7 "Reject private-room invitation" | `AC-INV-03-reject-invite.spec.ts`   |
+| AC-INV-04 | Banned user cannot consume invite | `POST /rooms/{id}/invitations/{id}/accept` (rejected) | —                                                               | —                                                              | RoomInvitation, RoomBan        | §7 "Accept private-room invitation" | `AC-INV-04-banned-invite.spec.ts`   |
 
 ## 9. Moderation and roles
 
-| AC ID | Capability | HTTP | WS event | State transition | Entities | Permissions row | Playwright test |
-|---|---|---|---|---|---|---|---|
-| AC-MOD-01 | Owner is always admin | (invariant) | — | — | RoomMembership | §8 "Remove owner admin status" | `AC-MOD-01-owner-always-admin.spec.ts` |
-| AC-MOD-02 | Remove = ban | `POST /rooms/{id}/members/{uid}/remove` | `room.membership.updated`, `room.ban.updated` | RoomMembership: active → left; RoomBan: none → active | RoomMembership, RoomBan | §8 "Remove member from room" | `AC-MOD-02-remove-is-ban.spec.ts` |
-| AC-MOD-03 | Admin views ban list | `GET /rooms/{id}/bans` | — | — | RoomBan | §8 "View room banned-user list" | `AC-MOD-03-ban-list.spec.ts` |
-| AC-MOD-04 | Admin unbans user | `DELETE /rooms/{id}/bans/{uid}` | `room.ban.updated` | RoomBan: active → removed | RoomBan | §8 "Unban user from room" | `AC-MOD-04-unban.spec.ts` |
-| AC-MOD-05 | Admin removes another admin | `POST /rooms/{id}/members/{uid}/remove-admin` | `room.membership.updated` | RoomMembership: role admin → member | RoomMembership | §8 "Remove admin status" | `AC-MOD-05-admin-removes-admin.spec.ts` |
-| AC-MOD-06 | Owner removes any admin | `POST /rooms/{id}/members/{uid}/remove-admin` | `room.membership.updated` | RoomMembership: role admin → member | RoomMembership | §8 "Remove admin status" | `AC-MOD-06-owner-removes-admin.spec.ts` |
-| AC-MOD-07 | Cannot strip owner admin | `POST /rooms/{id}/members/{uid}/remove-admin` (rejected if target=owner) | — | — | RoomMembership | §8 "Remove owner admin status" | `AC-MOD-07-owner-admin-protected.spec.ts` |
-| AC-MOD-08 | Admin promotes member to admin | `POST /rooms/{id}/members/{uid}/make-admin` | `room.membership.updated` | RoomMembership: role member → admin | RoomMembership | §8 "Promote member to admin" | `AC-MOD-08-admin-promotes-member.spec.ts` |
+| AC ID     | Capability                     | HTTP                                                                     | WS event                                      | State transition                                      | Entities                | Permissions row                 | Playwright test                           |
+| --------- | ------------------------------ | ------------------------------------------------------------------------ | --------------------------------------------- | ----------------------------------------------------- | ----------------------- | ------------------------------- | ----------------------------------------- |
+| AC-MOD-01 | Owner is always admin          | (invariant)                                                              | —                                             | —                                                     | RoomMembership          | §8 "Remove owner admin status"  | `AC-MOD-01-owner-always-admin.spec.ts`    |
+| AC-MOD-02 | Remove = ban                   | `POST /rooms/{id}/members/{uid}/remove`                                  | `room.membership.updated`, `room.ban.updated` | RoomMembership: active → left; RoomBan: none → active | RoomMembership, RoomBan | §8 "Remove member from room"    | `AC-MOD-02-remove-is-ban.spec.ts`         |
+| AC-MOD-03 | Admin views ban list           | `GET /rooms/{id}/bans`                                                   | —                                             | —                                                     | RoomBan                 | §8 "View room banned-user list" | `AC-MOD-03-ban-list.spec.ts`              |
+| AC-MOD-04 | Admin unbans user              | `DELETE /rooms/{id}/bans/{uid}`                                          | `room.ban.updated`                            | RoomBan: active → removed                             | RoomBan                 | §8 "Unban user from room"       | `AC-MOD-04-unban.spec.ts`                 |
+| AC-MOD-05 | Admin removes another admin    | `POST /rooms/{id}/members/{uid}/remove-admin`                            | `room.membership.updated`                     | RoomMembership: role admin → member                   | RoomMembership          | §8 "Remove admin status"        | `AC-MOD-05-admin-removes-admin.spec.ts`   |
+| AC-MOD-06 | Owner removes any admin        | `POST /rooms/{id}/members/{uid}/remove-admin`                            | `room.membership.updated`                     | RoomMembership: role admin → member                   | RoomMembership          | §8 "Remove admin status"        | `AC-MOD-06-owner-removes-admin.spec.ts`   |
+| AC-MOD-07 | Cannot strip owner admin       | `POST /rooms/{id}/members/{uid}/remove-admin` (rejected if target=owner) | —                                             | —                                                     | RoomMembership          | §8 "Remove owner admin status"  | `AC-MOD-07-owner-admin-protected.spec.ts` |
+| AC-MOD-08 | Admin promotes member to admin | `POST /rooms/{id}/members/{uid}/make-admin`                              | `room.membership.updated`                     | RoomMembership: role member → admin                   | RoomMembership          | §8 "Promote member to admin"    | `AC-MOD-08-admin-promotes-member.spec.ts` |
 
 ## 10. Messaging and history
 
-| AC ID | Capability | HTTP | WS event | State transition | Entities | Permissions row | Playwright test |
-|---|---|---|---|---|---|---|---|
-| AC-MSG-01 | Supported content forms | `POST /chats/{id}/messages` | `message.created` | Message: none → active | Message, Attachment | §9 "Send room message" | `AC-MSG-01-content-forms.spec.ts` |
-| AC-MSG-02 | 3 KB size limit | `POST /chats/{id}/messages` (rejected) | — | — | Message | §9 "Send room message" | `AC-MSG-02-size-limit.spec.ts` |
-| AC-MSG-03 | Stable ordering | `GET /chats/{id}/messages` | `message.created` | — | Message | §9 "View room message history" | `AC-MSG-03-ordering.spec.ts` |
-| AC-MSG-04 | Author edits own | `PATCH /messages/{id}` | `message.edited` | Message: active → edited | Message, MessageEditAudit | §9 "Edit own room message" | `AC-MSG-04-edit-own.spec.ts` |
-| AC-MSG-05 | Admin deletes other's | `DELETE /messages/{id}` | `message.deleted` | Message: active → deleted | Message | §9 "Delete another user's room message" | `AC-MSG-05-admin-delete.spec.ts` |
-| AC-MSG-06 | DM participants can't delete each other's | `DELETE /messages/{id}` (rejected) | — | — | Message | §5 "Delete another user's message in direct chat" | `AC-MSG-06-dm-delete-restricted.spec.ts` |
-| AC-MSG-07 | Offline → miss → catch up | `GET /chats/{id}/messages` | — | — | Message | §9 "View room message history" | `AC-MSG-07-offline-catchup.spec.ts` |
-| AC-MSG-08 | Infinite scroll | `GET /chats/{id}/messages?beforeSequence=…` | — | — | Message | §9 "View room message history" | `AC-MSG-08-infinite-scroll.spec.ts` |
+| AC ID     | Capability                                | HTTP                                        | WS event          | State transition          | Entities                  | Permissions row                                   | Playwright test                          |
+| --------- | ----------------------------------------- | ------------------------------------------- | ----------------- | ------------------------- | ------------------------- | ------------------------------------------------- | ---------------------------------------- |
+| AC-MSG-01 | Supported content forms                   | `POST /chats/{id}/messages`                 | `message.created` | Message: none → active    | Message, Attachment       | §9 "Send room message"                            | `AC-MSG-01-content-forms.spec.ts`        |
+| AC-MSG-02 | 3 KB size limit                           | `POST /chats/{id}/messages` (rejected)      | —                 | —                         | Message                   | §9 "Send room message"                            | `AC-MSG-02-size-limit.spec.ts`           |
+| AC-MSG-03 | Stable ordering                           | `GET /chats/{id}/messages`                  | `message.created` | —                         | Message                   | §9 "View room message history"                    | `AC-MSG-03-ordering.spec.ts`             |
+| AC-MSG-04 | Author edits own                          | `PATCH /messages/{id}`                      | `message.edited`  | Message: active → edited  | Message, MessageEditAudit | §9 "Edit own room message"                        | `AC-MSG-04-edit-own.spec.ts`             |
+| AC-MSG-05 | Admin deletes other's                     | `DELETE /messages/{id}`                     | `message.deleted` | Message: active → deleted | Message                   | §9 "Delete another user's room message"           | `AC-MSG-05-admin-delete.spec.ts`         |
+| AC-MSG-06 | DM participants can't delete each other's | `DELETE /messages/{id}` (rejected)          | —                 | —                         | Message                   | §5 "Delete another user's message in direct chat" | `AC-MSG-06-dm-delete-restricted.spec.ts` |
+| AC-MSG-07 | Offline → miss → catch up                 | `GET /chats/{id}/messages`                  | —                 | —                         | Message                   | §9 "View room message history"                    | `AC-MSG-07-offline-catchup.spec.ts`      |
+| AC-MSG-08 | Infinite scroll                           | `GET /chats/{id}/messages?beforeSequence=…` | —                 | —                         | Message                   | §9 "View room message history"                    | `AC-MSG-08-infinite-scroll.spec.ts`      |
 
 ## 11. Realtime delivery and continuity
 
-| AC ID | Capability | HTTP | WS event | State transition | Entities | Permissions row | Playwright test |
-|---|---|---|---|---|---|---|---|
-| AC-RT-01 | No REST polling | — | `message.created` | — | — | — | `AC-RT-01-realtime-delivery.spec.ts` |
-| AC-RT-02 | Hybrid recovery | `GET /chats/{id}/messages`, `sync.request` | `sync.response` | — | Message | — | `AC-RT-02-hybrid-recovery.spec.ts` |
-| AC-RT-03 | Next chat-local sequence | `POST /chats/{id}/messages` | `message.created` | Chat.current_sequence: N → N+1 | Chat, Message | — | `AC-RT-03-sequence-allocation.spec.ts` |
-| AC-RT-04 | Gap repair | `GET /chats/{id}/messages?afterSequence=…` | `sync.response` | — | Message | — | `AC-RT-04-gap-repair.spec.ts` |
-| AC-RT-05 | Dedup/reorder tolerance | — | `message.created` (duplicated in test) | — | — | — | `AC-RT-05-dedup.spec.ts` |
-| AC-RT-06 | No unbounded backlog | — | — | — | (in-memory OutboundSocketBuffer) | — | `AC-RT-06-bounded-buffer.spec.ts` |
+| AC ID    | Capability               | HTTP                                       | WS event                               | State transition               | Entities                         | Permissions row | Playwright test                        |
+| -------- | ------------------------ | ------------------------------------------ | -------------------------------------- | ------------------------------ | -------------------------------- | --------------- | -------------------------------------- |
+| AC-RT-01 | No REST polling          | —                                          | `message.created`                      | —                              | —                                | —               | `AC-RT-01-realtime-delivery.spec.ts`   |
+| AC-RT-02 | Hybrid recovery          | `GET /chats/{id}/messages`, `sync.request` | `sync.response`                        | —                              | Message                          | —               | `AC-RT-02-hybrid-recovery.spec.ts`     |
+| AC-RT-03 | Next chat-local sequence | `POST /chats/{id}/messages`                | `message.created`                      | Chat.current_sequence: N → N+1 | Chat, Message                    | —               | `AC-RT-03-sequence-allocation.spec.ts` |
+| AC-RT-04 | Gap repair               | `GET /chats/{id}/messages?afterSequence=…` | `sync.response`                        | —                              | Message                          | —               | `AC-RT-04-gap-repair.spec.ts`          |
+| AC-RT-05 | Dedup/reorder tolerance  | —                                          | `message.created` (duplicated in test) | —                              | —                                | —               | `AC-RT-05-dedup.spec.ts`               |
+| AC-RT-06 | No unbounded backlog     | —                                          | —                                      | —                              | (in-memory OutboundSocketBuffer) | —               | `AC-RT-06-bounded-buffer.spec.ts`      |
 
 ## 12. Attachments
 
-| AC ID | Capability | HTTP | WS event | State transition | Entities | Permissions row | Playwright test |
-|---|---|---|---|---|---|---|---|
-| AC-ATT-01 | Upload within limits | `POST /chats/{id}/attachments` | `message.created` (if linked) | Attachment: none → active | Attachment, Message | §10 "Upload file/image to room" | `AC-ATT-01-upload.spec.ts` |
-| AC-ATT-02 | Oversized rejected | `POST /chats/{id}/attachments` (rejected `PAYLOAD_TOO_LARGE`) | — | — | — | §10 | `AC-ATT-02-oversize-rejected.spec.ts` |
-| AC-ATT-03 | Auth based on current state | `GET /attachments/{id}/download` (rejected after membership loss) | — | — | Attachment, RoomMembership, RoomBan | §10 "Access previously uploaded file after losing room access" | `AC-ATT-03-current-auth.spec.ts` |
-| AC-ATT-04 | Room deletion removes attachments | `DELETE /rooms/{id}` | — | Attachment: active → deleted (soft, then hard-purge) | Attachment, Chat | §10 "Delete attachment by deleting containing room" | `AC-ATT-04-room-deletion-cleanup.spec.ts` |
-| AC-ATTACH-05 | No file-type restriction | `POST /chats/{id}/attachments` | — | — | Attachment | §10 | `AC-ATTACH-05-no-type-restriction.spec.ts` |
-| AC-ATTACH-06 | Filename preserved, sanitized on download | `POST /chats/{id}/attachments`, `GET /attachments/{id}/download` | — | — | Attachment | §10 "View original filename" | `AC-ATTACH-06-filename-handling.spec.ts` |
+| AC ID        | Capability                                | HTTP                                                              | WS event                      | State transition                                     | Entities                            | Permissions row                                                | Playwright test                            |
+| ------------ | ----------------------------------------- | ----------------------------------------------------------------- | ----------------------------- | ---------------------------------------------------- | ----------------------------------- | -------------------------------------------------------------- | ------------------------------------------ |
+| AC-ATT-01    | Upload within limits                      | `POST /chats/{id}/attachments`                                    | `message.created` (if linked) | Attachment: none → active                            | Attachment, Message                 | §10 "Upload file/image to room"                                | `AC-ATT-01-upload.spec.ts`                 |
+| AC-ATT-02    | Oversized rejected                        | `POST /chats/{id}/attachments` (rejected `PAYLOAD_TOO_LARGE`)     | —                             | —                                                    | —                                   | §10                                                            | `AC-ATT-02-oversize-rejected.spec.ts`      |
+| AC-ATT-03    | Auth based on current state               | `GET /attachments/{id}/download` (rejected after membership loss) | —                             | —                                                    | Attachment, RoomMembership, RoomBan | §10 "Access previously uploaded file after losing room access" | `AC-ATT-03-current-auth.spec.ts`           |
+| AC-ATT-04    | Room deletion removes attachments         | `DELETE /rooms/{id}`                                              | —                             | Attachment: active → deleted (soft, then hard-purge) | Attachment, Chat                    | §10 "Delete attachment by deleting containing room"            | `AC-ATT-04-room-deletion-cleanup.spec.ts`  |
+| AC-ATTACH-05 | No file-type restriction                  | `POST /chats/{id}/attachments`                                    | —                             | —                                                    | Attachment                          | §10                                                            | `AC-ATTACH-05-no-type-restriction.spec.ts` |
+| AC-ATTACH-06 | Filename preserved, sanitized on download | `POST /chats/{id}/attachments`, `GET /attachments/{id}/download`  | —                             | —                                                    | Attachment                          | §10 "View original filename"                                   | `AC-ATTACH-06-filename-handling.spec.ts`   |
 
 ## 13. Unread state
 
-| AC ID | Capability | HTTP | WS event | State transition | Entities | Permissions row | Playwright test |
-|---|---|---|---|---|---|---|---|
-| AC-UNREAD-01 | Room unread indicator | `GET /chats/{id}/read-state` (or bootstrap) | `readstate.updated`, `message.created` | — | ChatReadState, Message | §11 "See unread indicator for room" | `AC-UNREAD-01-room-indicator.spec.ts` |
-| AC-UNREAD-02 | DM unread indicator | `GET /chats/{id}/read-state` | `readstate.updated`, `message.created` | — | ChatReadState, Message | §11 "See unread indicator for direct chat" | `AC-UNREAD-02-dm-indicator.spec.ts` |
-| AC-UNREAD-03 | Explicit advance on open | `POST /chats/{id}/read` | `readstate.updated` | ChatReadState: lazy-created or updated; `last_read_sequence` ↑ | ChatReadState | §11 "Clear unread by opening chat" | `AC-UNREAD-03-explicit-advance.spec.ts` |
-| AC-UNREAD-04 | Multi-tab consistency | `POST /chats/{id}/read` (one tab) | `readstate.updated` (all user's sessions) | — | ChatReadState | §11 | `AC-UNREAD-04-multitab.spec.ts` |
+| AC ID        | Capability               | HTTP                                        | WS event                                  | State transition                                               | Entities               | Permissions row                            | Playwright test                         |
+| ------------ | ------------------------ | ------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------- | ---------------------- | ------------------------------------------ | --------------------------------------- |
+| AC-UNREAD-01 | Room unread indicator    | `GET /chats/{id}/read-state` (or bootstrap) | `readstate.updated`, `message.created`    | —                                                              | ChatReadState, Message | §11 "See unread indicator for room"        | `AC-UNREAD-01-room-indicator.spec.ts`   |
+| AC-UNREAD-02 | DM unread indicator      | `GET /chats/{id}/read-state`                | `readstate.updated`, `message.created`    | —                                                              | ChatReadState, Message | §11 "See unread indicator for direct chat" | `AC-UNREAD-02-dm-indicator.spec.ts`     |
+| AC-UNREAD-03 | Explicit advance on open | `POST /chats/{id}/read`                     | `readstate.updated`                       | ChatReadState: lazy-created or updated; `last_read_sequence` ↑ | ChatReadState          | §11 "Clear unread by opening chat"         | `AC-UNREAD-03-explicit-advance.spec.ts` |
+| AC-UNREAD-04 | Multi-tab consistency    | `POST /chats/{id}/read` (one tab)           | `readstate.updated` (all user's sessions) | —                                                              | ChatReadState          | §11                                        | `AC-UNREAD-04-multitab.spec.ts`         |
 
 ## 14. UI behavior
 
 UI ACs are exercised primarily through Playwright and may not involve a specific backend endpoint.
 
-| AC ID | Capability | HTTP | WS event | State transition | Entities | Permissions row | Playwright test |
-|---|---|---|---|---|---|---|---|
-| AC-UI-01 | Standard chat layout | — | — | — | — | — | `AC-UI-01-chat-layout.spec.ts` |
-| AC-UI-02 | Autoscroll at bottom | — | `message.created` | — | — | — | `AC-UI-02-autoscroll.spec.ts` |
-| AC-UI-03 | No forced autoscroll while reading | — | `message.created` | — | — | — | `AC-UI-03-no-forced-scroll.spec.ts` |
-| AC-UI-04 | Moderation via menus/dialogs | Various `/rooms/{id}/...` | — | — | — | §8 | `AC-UI-04-moderation-ui.spec.ts` |
+| AC ID    | Capability                         | HTTP                      | WS event          | State transition | Entities | Permissions row | Playwright test                     |
+| -------- | ---------------------------------- | ------------------------- | ----------------- | ---------------- | -------- | --------------- | ----------------------------------- |
+| AC-UI-01 | Standard chat layout               | —                         | —                 | —                | —        | —               | `AC-UI-01-chat-layout.spec.ts`      |
+| AC-UI-02 | Autoscroll at bottom               | —                         | `message.created` | —                | —        | —               | `AC-UI-02-autoscroll.spec.ts`       |
+| AC-UI-03 | No forced autoscroll while reading | —                         | `message.created` | —                | —        | —               | `AC-UI-03-no-forced-scroll.spec.ts` |
+| AC-UI-04 | Moderation via menus/dialogs       | Various `/rooms/{id}/...` | —                 | —                | —        | §8              | `AC-UI-04-moderation-ui.spec.ts`    |
 
 ## 15. Coverage invariants (CI-enforced)
 

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -132,7 +132,7 @@ Implementation status (WS-04 autorun, 2026-04-19):
 | AC-DM-05 | First DM creates direct chat      | `POST /chats/{chatId}/messages` (first) OR `POST /dm/{userId}/messages` (see note) | `message.created` | Chat: none → active; DirectChatParticipant × 2 created    | Chat, DirectChatParticipant, Message | §5 "Create direct chat by sending first message" | `AC-DM-05-first-dm.spec.ts`              |
 | AC-DM-06 | Block freezes DM                  | `POST /blocks/{userId}`                                                            | —                 | UserBlock: none → active; DirectChat: active → frozen     | UserBlock, Chat                      | §4 "Block another user"                          | `AC-DM-06-block-freezes-dm.spec.ts`      |
 
-Note: A dedicated `POST /dm/{userId}/messages` endpoint for DM creation is not yet in `api-and-events.md`. The current model uses `POST /chats/{chatId}/messages` which requires a chatId; the DM-creation flow needs a resolution (lazy-create on first message OR explicit `POST /dm/{userId}` endpoint). Resolve before AC-DM-05 implementation.
+Note: DM creation is resolved via `POST /dm/{userId}/messages` (api-and-events.md §5.6.1): the first send lazy-creates the direct chat + participant rows in a single transaction, then subsequent sends reuse the returned `chatId` against `POST /chats/{chatId}/messages`. The response reports `chat.created=true/false` so the caller can tell which path ran.
 
 ## 7. Rooms
 

--- a/docs/workstream-notes/ws-04-progress.md
+++ b/docs/workstream-notes/ws-04-progress.md
@@ -1,0 +1,49 @@
+# WS-04 autorun progress — 2026-04-19
+
+Branch: `feature/WS-04-autorun-20260419`
+
+## Scope decision
+
+WS-04 (Messaging and Durable History) covers AC-MSG-01..08, AC-RT-03,
+AC-DM-04, AC-DM-05, AC-UNREAD-01..03 — the full durable-history and
+read-state layer. WS-05 owns the websocket fan-out (`message.created`,
+`message.edited`, `message.deleted`, `readstate.updated`) and will layer
+on top of the commit hooks this workstream provides.
+
+This autorun lands the schema + HTTP layer end-to-end so WS-05 can plug in
+a publish-after-commit hook without further schema churn. Where a WS-03
+primitive is missing (no friendship writer yet — AC-DM-02 was deferred),
+this workstream extends `/__test/seed` to let Playwright seed a friendship
+for the AC-DM-05 spec rather than reaching into WS-03 code.
+
+### Delivery plan
+
+1. **Schema + migration 0004** — `messages`, `chat_read_state` with the
+   indexes from data-model.md §4.13 and §4.16.
+2. **AC-MSG-01 / AC-RT-03 / AC-MSG-02** — `POST /chats/{chatId}/messages`
+   with sequence allocation inside a single tx. Room-membership + DM
+   eligibility gates are re-used from WS-03.
+3. **AC-MSG-03 / AC-MSG-07 / AC-MSG-08** — `GET /chats/{chatId}/messages`
+   with `beforeSequence`, `afterSequence`, `limit`. Stable DESC ordering
+   by `(chat_id, sequence)`.
+4. **AC-MSG-04** — `PATCH /messages/{messageId}` (author-only, sets
+   `edited_at`).
+5. **AC-MSG-05 / AC-MSG-06** — `DELETE /messages/{messageId}` (author
+   anywhere; admins/owner in rooms only; DM participants can't delete
+   each other's).
+6. **AC-DM-04 / AC-DM-05** — `POST /dm/{userId}/messages` lazy-creates
+   a direct chat when friendship exists and no block; rejects otherwise.
+7. **AC-UNREAD-01/02/03** — `POST /chats/{chatId}/read` and
+   `GET /chats/{chatId}/read-state`.
+
+### Interfaces handed to other workstreams
+
+- WS-05: publish-after-commit point is `insertMessage` / `updateMessage`
+  / `softDeleteMessage` returning the row — the commit transaction is
+  strictly HTTP-local in this slice and does not emit events; WS-05 will
+  wrap the service calls with an outbox + ws fan-out layer.
+- WS-06: attachment linkage is a future `messageId` FK on attachments.
+  This workstream adds `metadata_json` jsonb on `messages` so attachment
+  references can be recorded without another migration.
+- WS-07: the response shapes in api-and-events.md §5.6 + §5.7 are the
+  frozen contract. No client-state implied; WS-07 owns the React surface.

--- a/docs/workstream-notes/ws-04-progress.md
+++ b/docs/workstream-notes/ws-04-progress.md
@@ -71,27 +71,57 @@ schema change was needed.
 
 A second CodeRabbit pass added three lower-severity nits (also addressed):
 
-4. `findUserActive` — added `deleted_at IS NULL` alongside `status='active'`
+1. `findUserActive` — added `deleted_at IS NULL` alongside `status='active'`
    to match the convention used by the other chat-side queries.
-5. `sendMessageToChat` and `sendDirectMessage` reply-target validation —
+2. `sendMessageToChat` and `sendDirectMessage` reply-target validation —
    reject soft-deleted targets the same way a cold miss is rejected, since
    a tombstoned target renders as a dangling pointer on the public surface.
 
-### Deferred: preflight-authz TOCTOU (CodeRabbit r3107554906 / r3107554910)
+### 2026-04-19 follow-up — preflight-authz TOCTOU (r3107554906 / r3107554910 / r3107540631)
 
-CodeRabbit also flagged two 🔴 Critical threads arguing that membership /
-moderator / friendship / block authz is preflight-only, so a concurrent
-revocation between the service check and the repo mutation can let one more
-message through. These are a different class from the concurrent-delete
-races fixed above — the FK stays intact, the window is bounded to a single
-in-flight request, and the AC-MSG / AC-DM criteria are phrased as preflight
-semantics rather than serialisable isolation between revoker and writer.
+CodeRabbit's third pass flagged two 🔴 Critical threads arguing that
+membership / moderator / friendship / block authz was preflight-only: a
+concurrent revocation between the service check and the repository
+mutation could still let one send/edit/delete commit against stale auth.
+A third 🔵 trivial thread asked for the reply-target soft-delete check in
+`sendDirectMessage` (landed earlier in commit `fb52954`).
 
-Atomizing authz into the mutation SQL would thread chat-type-aware params
-through four repo methods (`insertMessageWithSequence`, `updateMessageBody`,
-`softDeleteMessage`, `createDirectChatAndInsertMessage`) plus the read
-paths, with a predicate that differs per chat type (room-membership EXISTS
-vs. direct-participant + friendship + no-block EXISTS). That reshapes the
-service/repository boundary and is ADR-level — owed a dedicated ticket
-rather than rolled into this concurrent-delete follow-up. Threads resolved
-with a rationale reply on the PR so cascade can proceed.
+An earlier session drafted a deferral rationale for the two critical
+threads on the basis that atomizing authz into mutation SQL would reshape
+the service/repository boundary. On reflection that underestimated the
+change: the repo methods already receive a `chatId` + caller and the
+predicate only needs to flow in as a discriminated union, not a full
+boundary rewrite. This follow-up implements the fix in-scope:
+
+1. `messages/repository.ts` — new `WriteAuthScope` / `DeleteAuthScope` /
+   `ReadAuthScope` discriminated unions plus `callerIsActiveRoomMember`,
+   `callerIsDmParticipant`, and `dmPairStillEligible` SQL fragments.
+2. `insertMessageWithSequence`, `updateMessageBody`, `softDeleteMessage`,
+   `loadActiveChatMessageSnapshot` take an `authScope` and fold the
+   predicate into the UPDATE/SELECT's WHERE clause. Revocations that
+   commit between the preflight and the mutation now cause zero rows,
+   which the service maps to 403/404 mirroring the preflight response
+   shape.
+3. `softDeleteMessage` for rooms combines the active-membership check
+   with a `(rm.user_id = messages.author_user_id OR rm.role IN
+   ('admin','owner'))` disjunction, so moderator revocation fails
+   atomically even when the caller is not the author.
+4. `createDirectChatAndInsertMessage` — inside the existing advisory-lock
+   transaction, re-verifies the friendship (SELECT ... FOR UPDATE, which
+   forces any concurrent `UPDATE friendships SET ended_at = ...` to wait
+   on our tx) and re-reads the block rows. A new
+   `DmEligibilityRevokedError` sentinel is thrown from the tx; the
+   service catches it and surfaces `DM_NOT_ALLOWED`/403 matching the
+   preflight response. Block INSERTs that land after our block re-read
+   but before our message INSERT have no row to lock; closing that
+   narrow window requires the block writer to take the same pair
+   advisory lock, which lives outside the messages module.
+5. `upsertReadState` / `getReadState` — raw postgres-js tagged template
+   paths now embed a `buildRawReadAuthFragment` (EXISTS on
+   `room_memberships` or `direct_chat_participants`) in the `WHERE`
+   clause so read-state no longer upserts against a chat the caller has
+   been removed from. Zero rows → service returns 404.
+
+All three CR threads resolved via GraphQL `resolveReviewThread`
+mutations. Unit tests and doc-consistency / schema-drift checks pass; no
+schema change was required.

--- a/docs/workstream-notes/ws-04-progress.md
+++ b/docs/workstream-notes/ws-04-progress.md
@@ -47,3 +47,24 @@ for the AC-DM-05 spec rather than reaching into WS-03 code.
   references can be recorded without another migration.
 - WS-07: the response shapes in api-and-events.md §5.6 + §5.7 are the
   frozen contract. No client-state implied; WS-07 owns the React surface.
+
+## 2026-04-19 follow-up — CodeRabbit concurrent-delete threads
+
+CodeRabbit flagged three 🟠 Major race conditions where a soft-deleted chat
+could still accept writes or leak history between the service-level authz
+check and the subsequent data operation. All three fixes are query-level; no
+schema change was needed.
+
+1. `messages/repository.ts` — `updateMessageBody` and `softDeleteMessage` now
+   include an EXISTS predicate asserting `chats.deleted_at IS NULL` in the
+   UPDATE itself, so edits/deletes fail atomically if the parent chat was
+   soft-deleted concurrently.
+2. `messages/repository.ts` — `upsertReadState` rewritten as INSERT ... SELECT
+   from `chats` filtered by `deleted_at IS NULL`. When the chat is tombstoned
+   the SELECT yields no rows, no conflict is processed, RETURNING is empty,
+   and `advanceReadState` surfaces the standard 404.
+3. `messages/repository.ts` + `messages/service.ts` — `listMessages` replaced
+   by `loadActiveChatMessageSnapshot`, which reads the chat row (active-only)
+   and the page of messages in a single transaction and clamps
+   `sequence <= chat.current_sequence`. `fetchMessagesForChat` now uses the
+   snapshot both for head and list so the two reads always agree.

--- a/docs/workstream-notes/ws-04-progress.md
+++ b/docs/workstream-notes/ws-04-progress.md
@@ -68,3 +68,30 @@ schema change was needed.
    and the page of messages in a single transaction and clamps
    `sequence <= chat.current_sequence`. `fetchMessagesForChat` now uses the
    snapshot both for head and list so the two reads always agree.
+
+A second CodeRabbit pass added three lower-severity nits (also addressed):
+
+4. `findUserActive` — added `deleted_at IS NULL` alongside `status='active'`
+   to match the convention used by the other chat-side queries.
+5. `sendMessageToChat` and `sendDirectMessage` reply-target validation —
+   reject soft-deleted targets the same way a cold miss is rejected, since
+   a tombstoned target renders as a dangling pointer on the public surface.
+
+### Deferred: preflight-authz TOCTOU (CodeRabbit r3107554906 / r3107554910)
+
+CodeRabbit also flagged two 🔴 Critical threads arguing that membership /
+moderator / friendship / block authz is preflight-only, so a concurrent
+revocation between the service check and the repo mutation can let one more
+message through. These are a different class from the concurrent-delete
+races fixed above — the FK stays intact, the window is bounded to a single
+in-flight request, and the AC-MSG / AC-DM criteria are phrased as preflight
+semantics rather than serialisable isolation between revoker and writer.
+
+Atomizing authz into the mutation SQL would thread chat-type-aware params
+through four repo methods (`insertMessageWithSequence`, `updateMessageBody`,
+`softDeleteMessage`, `createDirectChatAndInsertMessage`) plus the read
+paths, with a predicate that differs per chat type (room-membership EXISTS
+vs. direct-participant + friendship + no-block EXISTS). That reshapes the
+service/repository boundary and is ADR-level — owed a dedicated ticket
+rather than rolled into this concurrent-delete follow-up. Threads resolved
+with a rationale reply on the PR so cascade can proceed.

--- a/e2e/specs/AC-DM-04-dm-eligibility.spec.ts
+++ b/e2e/specs/AC-DM-04-dm-eligibility.spec.ts
@@ -104,6 +104,27 @@ test.describe('AC-DM-04: DM requires friendship + no block', () => {
         error: { code: string };
       };
       expect(carolErr.error.code).toBe('DM_NOT_ALLOWED');
+
+      // The AC also requires that no writable direct chat is created
+      // for any rejected send. Prove it via the test-only peek: both
+      // Alice↔Bob and Alice↔Carol pairs must have zero direct chats
+      // after all three rejections.
+      const peek = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+      try {
+        const aliceBob = await peek.get(
+          `/__test/direct-chat-count?userA=${aliceSession.userId}&userB=${bobSession.userId}`,
+        );
+        expect(aliceBob.status()).toBe(200);
+        expect(((await aliceBob.json()) as { data: { count: number } }).data.count).toBe(0);
+
+        const aliceCarol = await peek.get(
+          `/__test/direct-chat-count?userA=${aliceSession.userId}&userB=${carolSession.userId}`,
+        );
+        expect(aliceCarol.status()).toBe(200);
+        expect(((await aliceCarol.json()) as { data: { count: number } }).data.count).toBe(0);
+      } finally {
+        await peek.dispose();
+      }
     } finally {
       await aliceCtx.dispose();
       await bobCtx.dispose();

--- a/e2e/specs/AC-DM-04-dm-eligibility.spec.ts
+++ b/e2e/specs/AC-DM-04-dm-eligibility.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+import { csrfHeaders } from '../utils/auth.js';
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function login(
+  ctx: Awaited<ReturnType<typeof apiRequest.newContext>>,
+  creds: { email: string; password: string },
+): Promise<{ userId: string; csrfToken: string }> {
+  const res = await ctx.post('/auth/login', {
+    data: { email: creds.email, password: creds.password },
+  });
+  if (res.status() !== 200) {
+    throw new Error(`login failed: ${res.status().toString()}`);
+  }
+  const setCookie = res.headers()['set-cookie'] ?? '';
+  const match = /(?:^|[\n;,]\s*)csrf_token=([^;\n]+)/.exec(setCookie);
+  const csrfToken = match?.[1] ?? '';
+  const body = (await res.json()) as { data: { user: { id: string } } };
+  return { userId: body.data.user.id, csrfToken };
+}
+
+// AC-DM-04: direct messaging requires friendship AND no block. The
+// three failure modes are: not friends, friends-but-blocked-one-way,
+// friends-but-blocked-other-way. Each returns `DM_NOT_ALLOWED` and
+// must NOT create a direct chat row.
+test.describe('AC-DM-04: DM requires friendship + no block', () => {
+  test('rejects non-friends and blocked pairs; no direct chat is created', async () => {
+    const suffix = uniqueSuffix();
+    const alice = {
+      email: `alice-${suffix}@example.com`,
+      username: `alice_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+    const bob = {
+      email: `bob-${suffix}@example.com`,
+      username: `bob_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+    const carol = {
+      email: `carol-${suffix}@example.com`,
+      username: `carol_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    // Alice ↔ Bob: not friends. Alice ↔ Carol: friends but Alice
+    // blocked Carol. Both Carol → Alice and Alice → Carol should be
+    // rejected because a block in either direction freezes DMs
+    // (AC-DM-06 + AC-DM-04).
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: {
+          strategy: 'truncate',
+          users: [alice, bob, carol],
+          friendships: [{ userA: alice.username, userB: carol.username }],
+          blocks: [{ blocker: alice.username, blocked: carol.username }],
+        },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const aliceCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    const bobCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    const carolCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const aliceSession = await login(aliceCtx, alice);
+      const bobSession = await login(bobCtx, bob);
+      const carolSession = await login(carolCtx, carol);
+
+      // Case 1: Alice → Bob, not friends → DM_NOT_ALLOWED.
+      const notFriends = await aliceCtx.post(`/dm/${bobSession.userId}/messages`, {
+        headers: csrfHeaders(aliceSession),
+        data: { bodyText: 'hi' },
+      });
+      expect(notFriends.status()).toBe(403);
+      const nfErr = (await notFriends.json()) as { error: { code: string } };
+      expect(nfErr.error.code).toBe('DM_NOT_ALLOWED');
+
+      // Case 2: Alice → Carol, friends but Alice blocked Carol →
+      // DM_NOT_ALLOWED (block takes precedence over friendship).
+      const blockedSend = await aliceCtx.post(`/dm/${carolSession.userId}/messages`, {
+        headers: csrfHeaders(aliceSession),
+        data: { bodyText: 'hi' },
+      });
+      expect(blockedSend.status()).toBe(403);
+      const blockedErr = (await blockedSend.json()) as {
+        error: { code: string };
+      };
+      expect(blockedErr.error.code).toBe('DM_NOT_ALLOWED');
+
+      // Case 3: Carol → Alice, friends but Carol was blocked by Alice
+      // → DM_NOT_ALLOWED (block is symmetric).
+      const carolReplies = await carolCtx.post(`/dm/${aliceSession.userId}/messages`, {
+        headers: csrfHeaders(carolSession),
+        data: { bodyText: 'hi' },
+      });
+      expect(carolReplies.status()).toBe(403);
+      const carolErr = (await carolReplies.json()) as {
+        error: { code: string };
+      };
+      expect(carolErr.error.code).toBe('DM_NOT_ALLOWED');
+    } finally {
+      await aliceCtx.dispose();
+      await bobCtx.dispose();
+      await carolCtx.dispose();
+    }
+  });
+});

--- a/e2e/specs/AC-DM-05-first-dm.spec.ts
+++ b/e2e/specs/AC-DM-05-first-dm.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+import { csrfHeaders } from '../utils/auth.js';
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function login(
+  ctx: Awaited<ReturnType<typeof apiRequest.newContext>>,
+  creds: { email: string; password: string },
+): Promise<{ userId: string; csrfToken: string }> {
+  const res = await ctx.post('/auth/login', {
+    data: { email: creds.email, password: creds.password },
+  });
+  if (res.status() !== 200) {
+    throw new Error(`login failed: ${res.status().toString()}`);
+  }
+  const setCookie = res.headers()['set-cookie'] ?? '';
+  const match = /(?:^|[\n;,]\s*)csrf_token=([^;\n]+)/.exec(setCookie);
+  const csrfToken = match?.[1] ?? '';
+  const body = (await res.json()) as { data: { user: { id: string } } };
+  return { userId: body.data.user.id, csrfToken };
+}
+
+// AC-DM-05: first successful DM creates the direct chat. The response
+// must advertise `chat.created=true` on the first call for a given
+// pair and `chat.created=false` on subsequent calls (same chat, same
+// chatId). Per api-and-events §5.6.1 the second send prefers the
+// chat-scoped endpoint — we assert the `chatId` matches across both
+// endpoints.
+test.describe('AC-DM-05: first DM creates the direct chat', () => {
+  test('creates chat with two participants on first send; reuses chat on second send', async () => {
+    const suffix = uniqueSuffix();
+    const alice = {
+      email: `alice-${suffix}@example.com`,
+      username: `alice_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+    const bob = {
+      email: `bob-${suffix}@example.com`,
+      username: `bob_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: {
+          strategy: 'truncate',
+          users: [alice, bob],
+          friendships: [{ userA: alice.username, userB: bob.username }],
+        },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const aliceCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    const bobCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const aliceSession = await login(aliceCtx, alice);
+      const bobSession = await login(bobCtx, bob);
+
+      const first = await aliceCtx.post(`/dm/${bobSession.userId}/messages`, {
+        headers: csrfHeaders(aliceSession),
+        data: { bodyText: 'hey bob' },
+      });
+      expect(first.status()).toBe(200);
+      const firstBody = (await first.json()) as {
+        data: {
+          chat: { id: string; created: boolean };
+          message: { sequence: number; authorUserId: string; chatId: string };
+        };
+      };
+      expect(firstBody.data.chat.created).toBe(true);
+      expect(firstBody.data.message.sequence).toBe(1);
+      expect(firstBody.data.message.authorUserId).toBe(aliceSession.userId);
+      expect(firstBody.data.message.chatId).toBe(firstBody.data.chat.id);
+
+      // Second send via DM endpoint — chat already exists, so
+      // `created=false`. Sequence advances to 2.
+      const second = await aliceCtx.post(`/dm/${bobSession.userId}/messages`, {
+        headers: csrfHeaders(aliceSession),
+        data: { bodyText: 'one more' },
+      });
+      expect(second.status()).toBe(200);
+      const secondBody = (await second.json()) as {
+        data: {
+          chat: { id: string; created: boolean };
+          message: { sequence: number; chatId: string };
+        };
+      };
+      expect(secondBody.data.chat.created).toBe(false);
+      expect(secondBody.data.chat.id).toBe(firstBody.data.chat.id);
+      expect(secondBody.data.message.sequence).toBe(2);
+
+      // Bob can send to the same chat via the chat-scoped endpoint
+      // because he's a participant.
+      const bobReply = await bobCtx.post(`/chats/${firstBody.data.chat.id}/messages`, {
+        headers: csrfHeaders(bobSession),
+        data: { bodyText: 'hi alice' },
+      });
+      expect(bobReply.status()).toBe(200);
+      const bobReplyBody = (await bobReply.json()) as {
+        data: { message: { sequence: number; authorUserId: string } };
+      };
+      expect(bobReplyBody.data.message.sequence).toBe(3);
+      expect(bobReplyBody.data.message.authorUserId).toBe(bobSession.userId);
+
+      // History shows both participants and chronological ordering.
+      const history = await aliceCtx.get(`/chats/${firstBody.data.chat.id}/messages`);
+      expect(history.status()).toBe(200);
+      const histBody = (await history.json()) as {
+        data: {
+          headSequence: number;
+          messages: { sequence: number; authorUserId: string }[];
+        };
+      };
+      expect(histBody.data.headSequence).toBe(3);
+      const authors = new Set(histBody.data.messages.map((m) => m.authorUserId));
+      expect(authors.has(aliceSession.userId)).toBe(true);
+      expect(authors.has(bobSession.userId)).toBe(true);
+    } finally {
+      await aliceCtx.dispose();
+      await bobCtx.dispose();
+    }
+  });
+});

--- a/e2e/specs/AC-MSG-01-content-forms.spec.ts
+++ b/e2e/specs/AC-MSG-01-content-forms.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+import { csrfHeaders, register } from '../utils/auth.js';
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+type MessageShape = {
+  id: string;
+  chatId: string;
+  sequence: number;
+  authorUserId: string;
+  kind: 'text' | 'system' | 'attachment';
+  bodyText: string | null;
+  replyToMessageId: string | null;
+  createdAt: string;
+  editedAt: string | null;
+  deletedAt: string | null;
+};
+
+type SendMessageResponse = { data: { message: MessageShape } };
+
+test.describe('AC-MSG-01: supported content forms', () => {
+  test('room member sends plain text, multiline text, emoji, and a threaded reply', async () => {
+    const suffix = uniqueSuffix();
+    const alice = {
+      email: `alice-${suffix}@example.com`,
+      username: `alice_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: { strategy: 'truncate' },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const ctx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const session = await register(ctx, alice);
+      const roomName = `room-${suffix}`;
+      const createRoom = await ctx.post('/rooms', {
+        headers: csrfHeaders(session),
+        data: { name: roomName, visibility: 'public' },
+      });
+      expect(createRoom.status()).toBe(200);
+      const {
+        data: { room },
+      } = (await createRoom.json()) as {
+        data: { room: { chatId: string } };
+      };
+
+      // Plain text
+      const sendPlain = await ctx.post(`/chats/${room.chatId}/messages`, {
+        headers: csrfHeaders(session),
+        data: { bodyText: 'hello room' },
+      });
+      expect(sendPlain.status()).toBe(200);
+      const plain = (await sendPlain.json()) as SendMessageResponse;
+      expect(plain.data.message.bodyText).toBe('hello room');
+      expect(plain.data.message.authorUserId).toBe(session.userId);
+      expect(plain.data.message.chatId).toBe(room.chatId);
+      expect(plain.data.message.kind).toBe('text');
+      expect(plain.data.message.sequence).toBe(1);
+
+      // Multiline + UTF-8 emoji
+      const multi = await ctx.post(`/chats/${room.chatId}/messages`, {
+        headers: csrfHeaders(session),
+        data: { bodyText: 'line 1\nline 2 — 🎉\nline 3' },
+      });
+      expect(multi.status()).toBe(200);
+      const multiBody = (await multi.json()) as SendMessageResponse;
+      expect(multiBody.data.message.bodyText).toBe('line 1\nline 2 — 🎉\nline 3');
+      expect(multiBody.data.message.sequence).toBe(2);
+
+      // Threaded reply: replyToMessageId on the second message pointing at
+      // the first.
+      const reply = await ctx.post(`/chats/${room.chatId}/messages`, {
+        headers: csrfHeaders(session),
+        data: {
+          bodyText: 'reply to first',
+          replyToMessageId: plain.data.message.id,
+        },
+      });
+      expect(reply.status()).toBe(200);
+      const replyBody = (await reply.json()) as SendMessageResponse;
+      expect(replyBody.data.message.replyToMessageId).toBe(plain.data.message.id);
+      expect(replyBody.data.message.sequence).toBe(3);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test('rejects non-members with NOT_A_MEMBER and unauthenticated callers', async () => {
+    const suffix = uniqueSuffix();
+    const alice = {
+      email: `alice-${suffix}@example.com`,
+      username: `alice_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+    const bob = {
+      email: `bob-${suffix}@example.com`,
+      username: `bob_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: { strategy: 'truncate' },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const aliceCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    const bobCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const aliceSession = await register(aliceCtx, alice);
+      const bobSession = await register(bobCtx, bob);
+      const roomName = `private-${suffix}`;
+      const createRoom = await aliceCtx.post('/rooms', {
+        headers: csrfHeaders(aliceSession),
+        data: { name: roomName, visibility: 'private' },
+      });
+      expect(createRoom.status()).toBe(200);
+      const {
+        data: { room },
+      } = (await createRoom.json()) as {
+        data: { room: { chatId: string } };
+      };
+
+      const notMember = await bobCtx.post(`/chats/${room.chatId}/messages`, {
+        headers: csrfHeaders(bobSession),
+        data: { bodyText: 'hi' },
+      });
+      expect(notMember.status()).toBe(403);
+      const err = (await notMember.json()) as {
+        error: { code: string };
+      };
+      expect(err.error.code).toBe('NOT_A_MEMBER');
+
+      const anon = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+      try {
+        const anonRes = await anon.post(`/chats/${room.chatId}/messages`, {
+          data: { bodyText: 'hi' },
+        });
+        expect([401, 403]).toContain(anonRes.status());
+      } finally {
+        await anon.dispose();
+      }
+    } finally {
+      await aliceCtx.dispose();
+      await bobCtx.dispose();
+    }
+  });
+});

--- a/e2e/specs/AC-MSG-02-size-limit.spec.ts
+++ b/e2e/specs/AC-MSG-02-size-limit.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+import { csrfHeaders, register } from '../utils/auth.js';
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+test.describe('AC-MSG-02: 3 KB message size limit', () => {
+  test('rejects messages whose UTF-8 byte length exceeds 3 KB', async () => {
+    const suffix = uniqueSuffix();
+    const alice = {
+      email: `alice-${suffix}@example.com`,
+      username: `alice_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: { strategy: 'truncate' },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const ctx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const session = await register(ctx, alice);
+      const createRoom = await ctx.post('/rooms', {
+        headers: csrfHeaders(session),
+        data: { name: `room-${suffix}`, visibility: 'public' },
+      });
+      expect(createRoom.status()).toBe(200);
+      const {
+        data: { room },
+      } = (await createRoom.json()) as {
+        data: { room: { chatId: string } };
+      };
+
+      // Exactly 3 KB ASCII (within the limit).
+      const exactly3k = 'a'.repeat(3 * 1024);
+      const okRes = await ctx.post(`/chats/${room.chatId}/messages`, {
+        headers: csrfHeaders(session),
+        data: { bodyText: exactly3k },
+      });
+      expect(okRes.status()).toBe(200);
+
+      // Just over 3 KB ASCII.
+      const over = 'a'.repeat(3 * 1024 + 1);
+      const overRes = await ctx.post(`/chats/${room.chatId}/messages`, {
+        headers: csrfHeaders(session),
+        data: { bodyText: over },
+      });
+      // The shared-schemas maxLength is a character count safety net that
+      // trips at the same threshold as the byte check, so either
+      // validation path is acceptable — both produce VALIDATION_ERROR.
+      expect(overRes.status()).toBe(400);
+      const overErr = (await overRes.json()) as { error: { code: string } };
+      expect(overErr.error.code).toBe('VALIDATION_ERROR');
+
+      // Multibyte case: 1024 × '😀' = 4096 bytes, well over 3 KB, but
+      // only 2048 JS code units. The byte-length gate must still reject
+      // it even though the JS string is under any naive character cap.
+      const overEmoji = '😀'.repeat(1024);
+      const emojiRes = await ctx.post(`/chats/${room.chatId}/messages`, {
+        headers: csrfHeaders(session),
+        data: { bodyText: overEmoji },
+      });
+      expect(emojiRes.status()).toBe(400);
+      const emojiErr = (await emojiRes.json()) as { error: { code: string } };
+      expect(emojiErr.error.code).toBe('VALIDATION_ERROR');
+
+      // Empty body rejected.
+      const emptyRes = await ctx.post(`/chats/${room.chatId}/messages`, {
+        headers: csrfHeaders(session),
+        data: { bodyText: '' },
+      });
+      expect(emptyRes.status()).toBe(400);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+});

--- a/e2e/specs/AC-MSG-03-ordering.spec.ts
+++ b/e2e/specs/AC-MSG-03-ordering.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+import { csrfHeaders, register } from '../utils/auth.js';
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+type MessageShape = {
+  id: string;
+  sequence: number;
+  bodyText: string | null;
+  createdAt: string;
+};
+
+test.describe('AC-MSG-03: stable chronological ordering', () => {
+  test('history reports messages in descending sequence with monotonically increasing createdAt', async () => {
+    const suffix = uniqueSuffix();
+    const alice = {
+      email: `alice-${suffix}@example.com`,
+      username: `alice_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: { strategy: 'truncate' },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const ctx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const session = await register(ctx, alice);
+      const createRoom = await ctx.post('/rooms', {
+        headers: csrfHeaders(session),
+        data: { name: `room-${suffix}`, visibility: 'public' },
+      });
+      expect(createRoom.status()).toBe(200);
+      const {
+        data: { room },
+      } = (await createRoom.json()) as {
+        data: { room: { chatId: string } };
+      };
+
+      // Send 5 messages serially. Serial sends guarantee createdAt is
+      // chronological; we validate that history mirrors the insertion order
+      // without any gaps in sequence numbers.
+      const bodies = ['first', 'second', 'third', 'fourth', 'fifth'];
+      for (const body of bodies) {
+        const res = await ctx.post(`/chats/${room.chatId}/messages`, {
+          headers: csrfHeaders(session),
+          data: { bodyText: body },
+        });
+        expect(res.status()).toBe(200);
+      }
+
+      const history = await ctx.get(`/chats/${room.chatId}/messages`);
+      expect(history.status()).toBe(200);
+      const body = (await history.json()) as {
+        data: {
+          chatId: string;
+          headSequence: number;
+          messages: MessageShape[];
+        };
+      };
+      expect(body.data.chatId).toBe(room.chatId);
+      expect(body.data.headSequence).toBe(5);
+      expect(body.data.messages).toHaveLength(5);
+      // DESC order — newest first.
+      const sequences = body.data.messages.map((m) => m.sequence);
+      expect(sequences).toEqual([5, 4, 3, 2, 1]);
+      // createdAt monotonically non-decreasing when read oldest → newest.
+      const oldestFirst = [...body.data.messages].reverse();
+      for (let i = 1; i < oldestFirst.length; i++) {
+        const prev = oldestFirst[i - 1];
+        const cur = oldestFirst[i];
+        if (prev === undefined || cur === undefined) continue;
+        expect(new Date(cur.createdAt).getTime()).toBeGreaterThanOrEqual(
+          new Date(prev.createdAt).getTime(),
+        );
+      }
+      // Body-text ordering mirrors insertion order (oldest → newest).
+      expect(oldestFirst.map((m) => m.bodyText)).toEqual(bodies);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+});

--- a/e2e/specs/AC-MSG-04-edit-own.spec.ts
+++ b/e2e/specs/AC-MSG-04-edit-own.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+import { csrfHeaders, register } from '../utils/auth.js';
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+type MessageShape = {
+  id: string;
+  sequence: number;
+  authorUserId: string;
+  bodyText: string | null;
+  editedAt: string | null;
+};
+
+test.describe('AC-MSG-04: author edits own message', () => {
+  test('author edit sets editedAt; non-author edit is FORBIDDEN', async () => {
+    const suffix = uniqueSuffix();
+    const alice = {
+      email: `alice-${suffix}@example.com`,
+      username: `alice_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+    const bob = {
+      email: `bob-${suffix}@example.com`,
+      username: `bob_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: {
+          strategy: 'truncate',
+          users: [alice, bob],
+          // Join Bob to Alice's about-to-be-created room so that
+          // non-author edits are truly tested against the same room.
+        },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const aliceCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    const bobCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      // Re-register via HTTP so we have session cookies and the CSRF
+      // token. The seeded users are wiped but re-inserted here, so to
+      // keep the test hermetic we truncate again then register.
+      const seed2 = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+      try {
+        const res = await seed2.post('/__test/seed', {
+          data: { strategy: 'truncate' },
+        });
+        expect(res.status()).toBe(200);
+      } finally {
+        await seed2.dispose();
+      }
+
+      const aliceSession = await register(aliceCtx, alice);
+      const bobSession = await register(bobCtx, bob);
+
+      const createRoom = await aliceCtx.post('/rooms', {
+        headers: csrfHeaders(aliceSession),
+        data: { name: `room-${suffix}`, visibility: 'public' },
+      });
+      expect(createRoom.status()).toBe(200);
+      const {
+        data: { room },
+      } = (await createRoom.json()) as {
+        data: { room: { chatId: string } };
+      };
+
+      const send = await aliceCtx.post(`/chats/${room.chatId}/messages`, {
+        headers: csrfHeaders(aliceSession),
+        data: { bodyText: 'original' },
+      });
+      expect(send.status()).toBe(200);
+      const sent = (await send.json()) as { data: { message: MessageShape } };
+      const messageId = sent.data.message.id;
+      expect(sent.data.message.editedAt).toBeNull();
+
+      const edit = await aliceCtx.patch(`/messages/${messageId}`, {
+        headers: csrfHeaders(aliceSession),
+        data: { bodyText: 'edited!' },
+      });
+      expect(edit.status()).toBe(200);
+      const edited = (await edit.json()) as { data: { message: MessageShape } };
+      expect(edited.data.message.bodyText).toBe('edited!');
+      expect(edited.data.message.editedAt).not.toBeNull();
+
+      // Non-author (Bob) is rejected with FORBIDDEN, even if Bob is later
+      // added to the same room. We don't have the room-join endpoint in
+      // WS-03 yet, so Bob isn't a member here; the author check fires
+      // first and returns 403 / FORBIDDEN regardless.
+      const bobEdit = await bobCtx.patch(`/messages/${messageId}`, {
+        headers: csrfHeaders(bobSession),
+        data: { bodyText: 'hostile edit' },
+      });
+      expect(bobEdit.status()).toBe(403);
+      const bobErr = (await bobEdit.json()) as { error: { code: string } };
+      expect(bobErr.error.code).toBe('FORBIDDEN');
+
+      // Subsequent author edit re-runs the editedAt timestamp without
+      // changing message identity — the AC.
+      const reedit = await aliceCtx.patch(`/messages/${messageId}`, {
+        headers: csrfHeaders(aliceSession),
+        data: { bodyText: 'edited again' },
+      });
+      expect(reedit.status()).toBe(200);
+      const re = (await reedit.json()) as { data: { message: MessageShape } };
+      expect(re.data.message.id).toBe(messageId);
+      expect(re.data.message.bodyText).toBe('edited again');
+    } finally {
+      await aliceCtx.dispose();
+      await bobCtx.dispose();
+    }
+  });
+});

--- a/e2e/specs/AC-MSG-04-edit-own.spec.ts
+++ b/e2e/specs/AC-MSG-04-edit-own.spec.ts
@@ -45,19 +45,6 @@ test.describe('AC-MSG-04: author edits own message', () => {
     const aliceCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
     const bobCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
     try {
-      // Re-register via HTTP so we have session cookies and the CSRF
-      // token. The seeded users are wiped but re-inserted here, so to
-      // keep the test hermetic we truncate again then register.
-      const seed2 = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
-      try {
-        const res = await seed2.post('/__test/seed', {
-          data: { strategy: 'truncate' },
-        });
-        expect(res.status()).toBe(200);
-      } finally {
-        await seed2.dispose();
-      }
-
       const aliceSession = await register(aliceCtx, alice);
       const bobSession = await register(bobCtx, bob);
 
@@ -71,6 +58,25 @@ test.describe('AC-MSG-04: author edits own message', () => {
       } = (await createRoom.json()) as {
         data: { room: { chatId: string } };
       };
+
+      // Put Bob in the room so that the author-check (not the
+      // membership gate) is the thing that rejects his edit. Without
+      // this, the non-author 403 could be masked by a NOT_A_MEMBER 403
+      // and the test wouldn't actually exercise AC-MSG-04.
+      const appendSeed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+      try {
+        const res = await appendSeed.post('/__test/seed', {
+          data: {
+            strategy: 'append',
+            roomMembershipsByChatId: [
+              { chatId: room.chatId, username: bob.username, role: 'member' },
+            ],
+          },
+        });
+        expect(res.status()).toBe(200);
+      } finally {
+        await appendSeed.dispose();
+      }
 
       const send = await aliceCtx.post(`/chats/${room.chatId}/messages`, {
         headers: csrfHeaders(aliceSession),
@@ -90,10 +96,8 @@ test.describe('AC-MSG-04: author edits own message', () => {
       expect(edited.data.message.bodyText).toBe('edited!');
       expect(edited.data.message.editedAt).not.toBeNull();
 
-      // Non-author (Bob) is rejected with FORBIDDEN, even if Bob is later
-      // added to the same room. We don't have the room-join endpoint in
-      // WS-03 yet, so Bob isn't a member here; the author check fires
-      // first and returns 403 / FORBIDDEN regardless.
+      // Non-author (Bob) is in the room but not the message author, so
+      // the edit is rejected because he isn't the author — the AC.
       const bobEdit = await bobCtx.patch(`/messages/${messageId}`, {
         headers: csrfHeaders(bobSession),
         data: { bodyText: 'hostile edit' },

--- a/e2e/specs/AC-MSG-04-edit-own.spec.ts
+++ b/e2e/specs/AC-MSG-04-edit-own.spec.ts
@@ -30,12 +30,7 @@ test.describe('AC-MSG-04: author edits own message', () => {
     const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
     try {
       const res = await seed.post('/__test/seed', {
-        data: {
-          strategy: 'truncate',
-          users: [alice, bob],
-          // Join Bob to Alice's about-to-be-created room so that
-          // non-author edits are truly tested against the same room.
-        },
+        data: { strategy: 'truncate' },
       });
       expect(res.status()).toBe(200);
     } finally {

--- a/e2e/specs/AC-MSG-05-admin-delete.spec.ts
+++ b/e2e/specs/AC-MSG-05-admin-delete.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+import { csrfHeaders, register } from '../utils/auth.js';
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+type MessageShape = {
+  id: string;
+  bodyText: string | null;
+  deletedAt: string | null;
+};
+
+test.describe("AC-MSG-05: admin deletes another user's room message", () => {
+  test('admin delete of member message succeeds; plain member is FORBIDDEN', async () => {
+    const suffix = uniqueSuffix();
+    const owner = {
+      email: `owner-${suffix}@example.com`,
+      username: `owner_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+    const adminUser = {
+      email: `admin-${suffix}@example.com`,
+      username: `admin_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+    const memberUser = {
+      email: `member-${suffix}@example.com`,
+      username: `member_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: { strategy: 'truncate' },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const ownerCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    const adminCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    const memberCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const ownerSession = await register(ownerCtx, owner);
+      const adminSession = await register(adminCtx, adminUser);
+      const memberSession = await register(memberCtx, memberUser);
+
+      const createRoom = await ownerCtx.post('/rooms', {
+        headers: csrfHeaders(ownerSession),
+        data: { name: `mod-${suffix}`, visibility: 'public' },
+      });
+      expect(createRoom.status()).toBe(200);
+      const {
+        data: { room },
+      } = (await createRoom.json()) as {
+        data: { room: { chatId: string } };
+      };
+
+      // Append-seed the room memberships for admin + member. WS-03
+      // hasn't landed join/promote endpoints; the test-only seed is the
+      // documented way to set up multi-role fixtures until it does.
+      const appendSeed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+      try {
+        const res = await appendSeed.post('/__test/seed', {
+          data: {
+            strategy: 'append',
+            roomMembershipsByChatId: [
+              { chatId: room.chatId, username: adminUser.username, role: 'admin' },
+              { chatId: room.chatId, username: memberUser.username, role: 'member' },
+            ],
+          },
+        });
+        expect(res.status()).toBe(200);
+      } finally {
+        await appendSeed.dispose();
+      }
+
+      // Member sends a message, admin deletes it.
+      const sent = await memberCtx.post(`/chats/${room.chatId}/messages`, {
+        headers: csrfHeaders(memberSession),
+        data: { bodyText: 'please delete me' },
+      });
+      expect(sent.status()).toBe(200);
+      const sentBody = (await sent.json()) as { data: { message: MessageShape } };
+      const messageId = sentBody.data.message.id;
+
+      const del = await adminCtx.delete(`/messages/${messageId}`, {
+        headers: csrfHeaders(adminSession),
+      });
+      expect(del.status()).toBe(200);
+
+      const history = await memberCtx.get(`/chats/${room.chatId}/messages`);
+      expect(history.status()).toBe(200);
+      const hist = (await history.json()) as {
+        data: { messages: MessageShape[] };
+      };
+      const hiddenRow = hist.data.messages.find((m) => m.id === messageId);
+      expect(hiddenRow).toBeDefined();
+      if (hiddenRow !== undefined) {
+        expect(hiddenRow.deletedAt).not.toBeNull();
+        // Deleted messages still appear in history with body_text nulled
+        // out (content hidden, row kept so sequence order is preserved).
+        expect(hiddenRow.bodyText).toBeNull();
+      }
+
+      // Second message, sent by admin, that a plain member tries to
+      // delete. Expect FORBIDDEN — member has no moderation rights.
+      const adminSend = await adminCtx.post(`/chats/${room.chatId}/messages`, {
+        headers: csrfHeaders(adminSession),
+        data: { bodyText: "admin's own words" },
+      });
+      expect(adminSend.status()).toBe(200);
+      const adminSent = (await adminSend.json()) as {
+        data: { message: MessageShape };
+      };
+      const memberDel = await memberCtx.delete(`/messages/${adminSent.data.message.id}`, {
+        headers: csrfHeaders(memberSession),
+      });
+      expect(memberDel.status()).toBe(403);
+      const memberErr = (await memberDel.json()) as { error: { code: string } };
+      expect(memberErr.error.code).toBe('FORBIDDEN');
+    } finally {
+      await ownerCtx.dispose();
+      await adminCtx.dispose();
+      await memberCtx.dispose();
+    }
+  });
+});

--- a/e2e/specs/AC-MSG-06-dm-delete-restricted.spec.ts
+++ b/e2e/specs/AC-MSG-06-dm-delete-restricted.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+import { csrfHeaders } from '../utils/auth.js';
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+type MessageShape = {
+  id: string;
+  chatId: string;
+  bodyText: string | null;
+  deletedAt: string | null;
+};
+
+// AC-MSG-06: direct-chat participants cannot delete each other's
+// messages. Direct chats have no admin role, so the caller must be the
+// author. A non-author participant gets FORBIDDEN.
+test.describe('AC-MSG-06: DM delete is restricted to author', () => {
+  test('non-author DM participant is FORBIDDEN; author may delete own', async () => {
+    const suffix = uniqueSuffix();
+    const alice = {
+      email: `alice-${suffix}@example.com`,
+      username: `alice_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+    const bob = {
+      email: `bob-${suffix}@example.com`,
+      username: `bob_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: {
+          strategy: 'truncate',
+          users: [alice, bob],
+          friendships: [{ userA: alice.username, userB: bob.username }],
+        },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const aliceCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    const bobCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      // Users exist in the DB already; login produces HTTP sessions.
+      const aliceSession = await loginFromSeed(aliceCtx, alice);
+      const bobSession = await loginFromSeed(bobCtx, bob);
+
+      // Alice sends the first DM, which lazy-creates the direct chat.
+      const sendFirst = await aliceCtx.post(`/dm/${bobSession.userId}/messages`, {
+        headers: csrfHeaders(aliceSession),
+        data: { bodyText: 'hello bob' },
+      });
+      expect(sendFirst.status()).toBe(200);
+      const firstBody = (await sendFirst.json()) as {
+        data: {
+          chat: { id: string; created: boolean };
+          message: MessageShape;
+        };
+      };
+      const chatId = firstBody.data.chat.id;
+
+      // Bob tries to delete Alice's message — rejected.
+      const bobDelete = await bobCtx.delete(`/messages/${firstBody.data.message.id}`, {
+        headers: csrfHeaders(bobSession),
+      });
+      expect(bobDelete.status()).toBe(403);
+      const err = (await bobDelete.json()) as { error: { code: string } };
+      expect(err.error.code).toBe('FORBIDDEN');
+
+      // Alice deletes her own — allowed.
+      const aliceDelete = await aliceCtx.delete(`/messages/${firstBody.data.message.id}`, {
+        headers: csrfHeaders(aliceSession),
+      });
+      expect(aliceDelete.status()).toBe(200);
+
+      // Deleted message still in history; content hidden.
+      const history = await aliceCtx.get(`/chats/${chatId}/messages`);
+      expect(history.status()).toBe(200);
+      const historyBody = (await history.json()) as {
+        data: { messages: MessageShape[] };
+      };
+      const row = historyBody.data.messages.find((m) => m.id === firstBody.data.message.id);
+      expect(row).toBeDefined();
+      expect(row?.deletedAt).not.toBeNull();
+      expect(row?.bodyText).toBeNull();
+    } finally {
+      await aliceCtx.dispose();
+      await bobCtx.dispose();
+    }
+  });
+});
+
+async function loginFromSeed(
+  ctx: Awaited<ReturnType<typeof apiRequest.newContext>>,
+  creds: { email: string; password: string },
+): Promise<{ userId: string; csrfToken: string }> {
+  const res = await ctx.post('/auth/login', {
+    data: { email: creds.email, password: creds.password },
+  });
+  if (res.status() !== 200) {
+    throw new Error(`login failed: ${res.status().toString()}`);
+  }
+  const setCookie = res.headers()['set-cookie'] ?? '';
+  const match = /(?:^|[\n;,]\s*)csrf_token=([^;\n]+)/.exec(setCookie);
+  const csrfToken = match?.[1] ?? '';
+  if (csrfToken.length === 0) {
+    throw new Error('login did not set csrf_token');
+  }
+  const body = (await res.json()) as { data: { user: { id: string } } };
+  return { userId: body.data.user.id, csrfToken };
+}

--- a/e2e/specs/AC-MSG-07-offline-catchup.spec.ts
+++ b/e2e/specs/AC-MSG-07-offline-catchup.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+import { csrfHeaders, register } from '../utils/auth.js';
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+type MessageShape = { id: string; sequence: number; bodyText: string | null };
+
+// AC-MSG-07 ("offline recipient sees missed messages after reconnect")
+// has no live websocket component in WS-04 — we simulate offline by
+// letting one context sit idle while another writes, then re-fetch via
+// GET /chats/{id}/messages?afterSequence=N and confirm the missed
+// window is retrievable from durable history.
+test.describe('AC-MSG-07: offline → miss → catch up via history', () => {
+  test('afterSequence returns every message newer than the cursor', async () => {
+    const suffix = uniqueSuffix();
+    const alice = {
+      email: `alice-${suffix}@example.com`,
+      username: `alice_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: { strategy: 'truncate' },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const ctx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const session = await register(ctx, alice);
+      const createRoom = await ctx.post('/rooms', {
+        headers: csrfHeaders(session),
+        data: { name: `room-${suffix}`, visibility: 'public' },
+      });
+      expect(createRoom.status()).toBe(200);
+      const {
+        data: { room },
+      } = (await createRoom.json()) as {
+        data: { room: { chatId: string } };
+      };
+
+      for (let i = 1; i <= 5; i++) {
+        const res = await ctx.post(`/chats/${room.chatId}/messages`, {
+          headers: csrfHeaders(session),
+          data: { bodyText: `msg-${i.toString()}` },
+        });
+        expect(res.status()).toBe(200);
+      }
+
+      // Client "goes offline" after seeing sequence 2. Three more
+      // messages land while they're away.
+      const knownCursor = 2;
+      for (let i = 6; i <= 8; i++) {
+        const res = await ctx.post(`/chats/${room.chatId}/messages`, {
+          headers: csrfHeaders(session),
+          data: { bodyText: `missed-${i.toString()}` },
+        });
+        expect(res.status()).toBe(200);
+      }
+
+      const catchup = await ctx.get(
+        `/chats/${room.chatId}/messages?afterSequence=${knownCursor.toString()}`,
+      );
+      expect(catchup.status()).toBe(200);
+      const body = (await catchup.json()) as {
+        data: { headSequence: number; messages: MessageShape[] };
+      };
+      expect(body.data.headSequence).toBe(8);
+      const sequences = body.data.messages.map((m) => m.sequence).sort((a, b) => a - b);
+      expect(sequences).toEqual([3, 4, 5, 6, 7, 8]);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+});

--- a/e2e/specs/AC-MSG-08-infinite-scroll.spec.ts
+++ b/e2e/specs/AC-MSG-08-infinite-scroll.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+import { csrfHeaders, register } from '../utils/auth.js';
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+type MessageShape = { sequence: number; bodyText: string | null };
+
+// AC-MSG-08: `beforeSequence` walks back through history without
+// replacing newer-loaded messages. We send 25 messages, then page
+// backwards with `limit=10` twice and confirm the returned windows
+// don't overlap.
+test.describe('AC-MSG-08: infinite scroll via beforeSequence + limit', () => {
+  test('beforeSequence returns older-than-cursor messages; non-overlapping pages', async () => {
+    const suffix = uniqueSuffix();
+    const alice = {
+      email: `alice-${suffix}@example.com`,
+      username: `alice_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: { strategy: 'truncate' },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const ctx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const session = await register(ctx, alice);
+      const createRoom = await ctx.post('/rooms', {
+        headers: csrfHeaders(session),
+        data: { name: `room-${suffix}`, visibility: 'public' },
+      });
+      expect(createRoom.status()).toBe(200);
+      const {
+        data: { room },
+      } = (await createRoom.json()) as {
+        data: { room: { chatId: string } };
+      };
+
+      const N = 25;
+      for (let i = 1; i <= N; i++) {
+        const res = await ctx.post(`/chats/${room.chatId}/messages`, {
+          headers: csrfHeaders(session),
+          data: { bodyText: `msg-${i.toString().padStart(2, '0')}` },
+        });
+        expect(res.status()).toBe(200);
+      }
+
+      const pageSize = 10;
+      // First page: latest 10 (sequences 25..16, DESC)
+      const page1 = await ctx.get(`/chats/${room.chatId}/messages?limit=${pageSize.toString()}`);
+      expect(page1.status()).toBe(200);
+      const p1 = (await page1.json()) as {
+        data: { headSequence: number; messages: MessageShape[] };
+      };
+      expect(p1.data.headSequence).toBe(N);
+      const p1Sequences = p1.data.messages.map((m) => m.sequence);
+      expect(p1Sequences).toEqual([25, 24, 23, 22, 21, 20, 19, 18, 17, 16]);
+
+      const firstOldestInPage1 = p1Sequences[p1Sequences.length - 1];
+      if (firstOldestInPage1 === undefined) {
+        throw new Error('page1 is empty');
+      }
+
+      // Second page: older than 16 — should be 15..6.
+      const page2 = await ctx.get(
+        `/chats/${room.chatId}/messages?beforeSequence=${firstOldestInPage1.toString()}&limit=${pageSize.toString()}`,
+      );
+      expect(page2.status()).toBe(200);
+      const p2 = (await page2.json()) as {
+        data: { messages: MessageShape[] };
+      };
+      const p2Sequences = p2.data.messages.map((m) => m.sequence);
+      expect(p2Sequences).toEqual([15, 14, 13, 12, 11, 10, 9, 8, 7, 6]);
+
+      // Non-overlap invariant: the two windows share no sequence
+      // numbers.
+      const overlap = p1Sequences.filter((s) => p2Sequences.includes(s));
+      expect(overlap).toEqual([]);
+
+      // Third page: reach the tail.
+      const page3 = await ctx.get(
+        `/chats/${room.chatId}/messages?beforeSequence=6&limit=${pageSize.toString()}`,
+      );
+      expect(page3.status()).toBe(200);
+      const p3 = (await page3.json()) as {
+        data: { messages: MessageShape[] };
+      };
+      const p3Sequences = p3.data.messages.map((m) => m.sequence);
+      expect(p3Sequences).toEqual([5, 4, 3, 2, 1]);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+});

--- a/e2e/specs/AC-RT-03-sequence-allocation.spec.ts
+++ b/e2e/specs/AC-RT-03-sequence-allocation.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+import { csrfHeaders, register } from '../utils/auth.js';
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// AC-RT-03: "Every persisted message gets the next chat-local sequence".
+// The sequence is incremented atomically by the send-message transaction,
+// so concurrent sends produce a contiguous block with no duplicates and
+// no gaps — proven here by firing N parallel sends and inspecting the
+// resulting set of allocated sequences.
+test.describe('AC-RT-03: chat-local sequence allocation', () => {
+  test('concurrent sends receive unique, contiguous sequences starting at 1', async () => {
+    const suffix = uniqueSuffix();
+    const alice = {
+      email: `alice-${suffix}@example.com`,
+      username: `alice_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: { strategy: 'truncate' },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const ctx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const session = await register(ctx, alice);
+      const createRoom = await ctx.post('/rooms', {
+        headers: csrfHeaders(session),
+        data: { name: `room-${suffix}`, visibility: 'public' },
+      });
+      expect(createRoom.status()).toBe(200);
+      const {
+        data: { room },
+      } = (await createRoom.json()) as {
+        data: { room: { chatId: string } };
+      };
+
+      const N = 10;
+      const sends = Array.from({ length: N }, (_unused, i) =>
+        ctx.post(`/chats/${room.chatId}/messages`, {
+          headers: csrfHeaders(session),
+          data: { bodyText: `concurrent-${i.toString()}` },
+        }),
+      );
+      const results = await Promise.all(sends);
+      const sequences: number[] = [];
+      for (const res of results) {
+        expect(res.status()).toBe(200);
+        const body = (await res.json()) as { data: { message: { sequence: number } } };
+        sequences.push(body.data.message.sequence);
+      }
+      const sorted = [...sequences].sort((a, b) => a - b);
+      expect(new Set(sorted).size).toBe(N);
+      expect(sorted).toEqual(Array.from({ length: N }, (_unused, i) => i + 1));
+
+      // History confirms the head sequence landed at N.
+      const history = await ctx.get(`/chats/${room.chatId}/messages`);
+      expect(history.status()).toBe(200);
+      const hbody = (await history.json()) as {
+        data: { headSequence: number; messages: { sequence: number }[] };
+      };
+      expect(hbody.data.headSequence).toBe(N);
+      expect(hbody.data.messages[0]?.sequence).toBe(N);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+});

--- a/e2e/specs/AC-UNREAD-01-room-indicator.spec.ts
+++ b/e2e/specs/AC-UNREAD-01-room-indicator.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+import { csrfHeaders, register } from '../utils/auth.js';
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// AC-UNREAD-01: an empty read-state row (never-opened) plus an
+// existing message produces hasUnread=true. After advancing read-state
+// to head, hasUnread flips to false.
+test.describe('AC-UNREAD-01: room unread indicator', () => {
+  test('never-opened chat with messages reports hasUnread=true', async () => {
+    const suffix = uniqueSuffix();
+    const owner = {
+      email: `owner-${suffix}@example.com`,
+      username: `owner_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+    const reader = {
+      email: `reader-${suffix}@example.com`,
+      username: `reader_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: { strategy: 'truncate' },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const ownerCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    const readerCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const ownerSession = await register(ownerCtx, owner);
+      await register(readerCtx, reader);
+
+      const createRoom = await ownerCtx.post('/rooms', {
+        headers: csrfHeaders(ownerSession),
+        data: { name: `room-${suffix}`, visibility: 'public' },
+      });
+      expect(createRoom.status()).toBe(200);
+      const {
+        data: { room },
+      } = (await createRoom.json()) as {
+        data: { room: { chatId: string } };
+      };
+
+      const appendSeed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+      try {
+        const res = await appendSeed.post('/__test/seed', {
+          data: {
+            strategy: 'append',
+            roomMembershipsByChatId: [
+              { chatId: room.chatId, username: reader.username, role: 'member' },
+            ],
+          },
+        });
+        expect(res.status()).toBe(200);
+      } finally {
+        await appendSeed.dispose();
+      }
+
+      // Owner posts 3 messages. Reader never opens the chat yet.
+      for (let i = 1; i <= 3; i++) {
+        const res = await ownerCtx.post(`/chats/${room.chatId}/messages`, {
+          headers: csrfHeaders(ownerSession),
+          data: { bodyText: `msg-${i.toString()}` },
+        });
+        expect(res.status()).toBe(200);
+      }
+
+      const readerState = await readerCtx.get(`/chats/${room.chatId}/read-state`);
+      expect(readerState.status()).toBe(200);
+      const rs = (await readerState.json()) as {
+        data: {
+          lastReadSequence: number;
+          headSequence: number;
+          hasUnread: boolean;
+        };
+      };
+      expect(rs.data.lastReadSequence).toBe(0);
+      expect(rs.data.headSequence).toBe(3);
+      expect(rs.data.hasUnread).toBe(true);
+    } finally {
+      await ownerCtx.dispose();
+      await readerCtx.dispose();
+    }
+  });
+});

--- a/e2e/specs/AC-UNREAD-02-dm-indicator.spec.ts
+++ b/e2e/specs/AC-UNREAD-02-dm-indicator.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+import { csrfHeaders } from '../utils/auth.js';
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function login(
+  ctx: Awaited<ReturnType<typeof apiRequest.newContext>>,
+  creds: { email: string; password: string },
+): Promise<{ userId: string; csrfToken: string }> {
+  const res = await ctx.post('/auth/login', {
+    data: { email: creds.email, password: creds.password },
+  });
+  if (res.status() !== 200) {
+    throw new Error(`login failed: ${res.status().toString()}`);
+  }
+  const setCookie = res.headers()['set-cookie'] ?? '';
+  const match = /(?:^|[\n;,]\s*)csrf_token=([^;\n]+)/.exec(setCookie);
+  const body = (await res.json()) as { data: { user: { id: string } } };
+  return { userId: body.data.user.id, csrfToken: match?.[1] ?? '' };
+}
+
+// AC-UNREAD-02: direct-chat unread indicator. A sends first DM, B's
+// read-state reports hasUnread=true until B advances.
+test.describe('AC-UNREAD-02: DM unread indicator', () => {
+  test('recipient sees hasUnread=true until they advance read state', async () => {
+    const suffix = uniqueSuffix();
+    const alice = {
+      email: `alice-${suffix}@example.com`,
+      username: `alice_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+    const bob = {
+      email: `bob-${suffix}@example.com`,
+      username: `bob_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: {
+          strategy: 'truncate',
+          users: [alice, bob],
+          friendships: [{ userA: alice.username, userB: bob.username }],
+        },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const aliceCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    const bobCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const aliceSession = await login(aliceCtx, alice);
+      const bobSession = await login(bobCtx, bob);
+
+      const sent = await aliceCtx.post(`/dm/${bobSession.userId}/messages`, {
+        headers: csrfHeaders(aliceSession),
+        data: { bodyText: 'hey bob' },
+      });
+      expect(sent.status()).toBe(200);
+      const sentBody = (await sent.json()) as {
+        data: { chat: { id: string }; message: { sequence: number } };
+      };
+      const chatId = sentBody.data.chat.id;
+
+      const bobState = await bobCtx.get(`/chats/${chatId}/read-state`);
+      expect(bobState.status()).toBe(200);
+      const bs = (await bobState.json()) as {
+        data: { hasUnread: boolean; lastReadSequence: number; headSequence: number };
+      };
+      expect(bs.data.lastReadSequence).toBe(0);
+      expect(bs.data.headSequence).toBe(1);
+      expect(bs.data.hasUnread).toBe(true);
+
+      // Author's own side reports no unread for their own send (they
+      // are synced to head implicitly? No — server is authoritative and
+      // won't lie about this; the author can post and still show
+      // hasUnread=true because they haven't explicitly advanced. The
+      // AC clears unread only via POST /chats/{id}/read, so assert the
+      // author is also hasUnread=true until they advance.)
+      const aliceState = await aliceCtx.get(`/chats/${chatId}/read-state`);
+      expect(aliceState.status()).toBe(200);
+      const as = (await aliceState.json()) as {
+        data: { hasUnread: boolean; lastReadSequence: number };
+      };
+      expect(as.data.lastReadSequence).toBe(0);
+      expect(as.data.hasUnread).toBe(true);
+    } finally {
+      await aliceCtx.dispose();
+      await bobCtx.dispose();
+    }
+  });
+});

--- a/e2e/specs/AC-UNREAD-03-explicit-advance.spec.ts
+++ b/e2e/specs/AC-UNREAD-03-explicit-advance.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+import { csrfHeaders, register } from '../utils/auth.js';
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// AC-UNREAD-03: POST /chats/{id}/read moves the server-side
+// last_read_sequence forward; the server clamps over-advances to head
+// without error.
+test.describe('AC-UNREAD-03: explicit read-state advance', () => {
+  test('advance sets lastReadSequence; clamps over-advance to head', async () => {
+    const suffix = uniqueSuffix();
+    const owner = {
+      email: `owner-${suffix}@example.com`,
+      username: `owner_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+    const reader = {
+      email: `reader-${suffix}@example.com`,
+      username: `reader_${suffix}`.replace(/-/g, '_'),
+      password: 'StrongPassword123!',
+    };
+
+    const seed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const res = await seed.post('/__test/seed', {
+        data: { strategy: 'truncate' },
+      });
+      expect(res.status()).toBe(200);
+    } finally {
+      await seed.dispose();
+    }
+
+    const ownerCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    const readerCtx = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+    try {
+      const ownerSession = await register(ownerCtx, owner);
+      const readerSession = await register(readerCtx, reader);
+
+      const createRoom = await ownerCtx.post('/rooms', {
+        headers: csrfHeaders(ownerSession),
+        data: { name: `room-${suffix}`, visibility: 'public' },
+      });
+      expect(createRoom.status()).toBe(200);
+      const {
+        data: { room },
+      } = (await createRoom.json()) as {
+        data: { room: { chatId: string } };
+      };
+
+      const appendSeed = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+      try {
+        const res = await appendSeed.post('/__test/seed', {
+          data: {
+            strategy: 'append',
+            roomMembershipsByChatId: [
+              { chatId: room.chatId, username: reader.username, role: 'member' },
+            ],
+          },
+        });
+        expect(res.status()).toBe(200);
+      } finally {
+        await appendSeed.dispose();
+      }
+
+      for (let i = 1; i <= 4; i++) {
+        const res = await ownerCtx.post(`/chats/${room.chatId}/messages`, {
+          headers: csrfHeaders(ownerSession),
+          data: { bodyText: `msg-${i.toString()}` },
+        });
+        expect(res.status()).toBe(200);
+      }
+
+      // Reader advances to sequence 4 (the current head).
+      const advance = await readerCtx.post(`/chats/${room.chatId}/read`, {
+        headers: csrfHeaders(readerSession),
+        data: { readUpToSequence: 4 },
+      });
+      expect(advance.status()).toBe(200);
+      const body = (await advance.json()) as {
+        data: { chatId: string; lastReadSequence: number };
+      };
+      expect(body.data.chatId).toBe(room.chatId);
+      expect(body.data.lastReadSequence).toBe(4);
+
+      const after = await readerCtx.get(`/chats/${room.chatId}/read-state`);
+      expect(after.status()).toBe(200);
+      const afterBody = (await after.json()) as {
+        data: { lastReadSequence: number; headSequence: number; hasUnread: boolean };
+      };
+      expect(afterBody.data.lastReadSequence).toBe(4);
+      expect(afterBody.data.hasUnread).toBe(false);
+
+      // Over-advance is silently clamped to head, not rejected.
+      const over = await readerCtx.post(`/chats/${room.chatId}/read`, {
+        headers: csrfHeaders(readerSession),
+        data: { readUpToSequence: 10_000 },
+      });
+      expect(over.status()).toBe(200);
+      const overBody = (await over.json()) as {
+        data: { lastReadSequence: number };
+      };
+      expect(overBody.data.lastReadSequence).toBe(4);
+
+      // Monotonicity: a caller cannot move last_read_sequence backwards
+      // (the server uses GREATEST). Another advance at 2 leaves
+      // lastReadSequence at 4.
+      const back = await readerCtx.post(`/chats/${room.chatId}/read`, {
+        headers: csrfHeaders(readerSession),
+        data: { readUpToSequence: 2 },
+      });
+      expect(back.status()).toBe(200);
+      const backBody = (await back.json()) as {
+        data: { lastReadSequence: number };
+      };
+      expect(backBody.data.lastReadSequence).toBe(4);
+    } finally {
+      await ownerCtx.dispose();
+      await readerCtx.dispose();
+    }
+  });
+});

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -5,5 +5,6 @@ export * from './schemas/auth.js';
 export * from './schemas/rooms.js';
 export * from './schemas/friends.js';
 export * from './schemas/blocks.js';
+export * from './schemas/messages.js';
 export * from './constants/error-codes.js';
 export * from './constants/limits.js';

--- a/packages/shared-schemas/src/schemas/messages.ts
+++ b/packages/shared-schemas/src/schemas/messages.ts
@@ -1,0 +1,120 @@
+import { Type, type Static } from '@sinclair/typebox';
+import { SuccessEnvelope } from './envelopes.js';
+import { MESSAGE_MAX_BYTES } from '../constants/limits.js';
+
+// Note: `maxLength` is a character count on the JSON-Schema side; the
+// real byte-based limit from AC-MSG-02 is enforced in the service so that
+// multibyte characters are measured correctly. The schema's `maxLength`
+// here is a cheap up-front guard that can never be tighter than
+// MESSAGE_MAX_BYTES bytes once encoded in UTF-8.
+export const MESSAGE_BODY_MAX_LENGTH = MESSAGE_MAX_BYTES;
+
+export const MessageKindSchema = Type.Union([
+  Type.Literal('text'),
+  Type.Literal('system'),
+  Type.Literal('attachment'),
+]);
+export type MessageKind = Static<typeof MessageKindSchema>;
+
+export const MessagePublicSchema = Type.Object({
+  id: Type.String({ format: 'uuid' }),
+  chatId: Type.String({ format: 'uuid' }),
+  sequence: Type.Integer({ minimum: 1 }),
+  authorUserId: Type.String({ format: 'uuid' }),
+  kind: MessageKindSchema,
+  bodyText: Type.Union([Type.String(), Type.Null()]),
+  replyToMessageId: Type.Union([Type.String({ format: 'uuid' }), Type.Null()]),
+  createdAt: Type.String({ format: 'date-time' }),
+  editedAt: Type.Union([Type.String({ format: 'date-time' }), Type.Null()]),
+  deletedAt: Type.Union([Type.String({ format: 'date-time' }), Type.Null()]),
+});
+export type MessagePublic = Static<typeof MessagePublicSchema>;
+
+export const SendMessageRequestSchema = Type.Object(
+  {
+    bodyText: Type.String({ minLength: 1, maxLength: MESSAGE_BODY_MAX_LENGTH }),
+    replyToMessageId: Type.Optional(Type.Union([Type.String({ format: 'uuid' }), Type.Null()])),
+  },
+  { additionalProperties: false },
+);
+export type SendMessageRequest = Static<typeof SendMessageRequestSchema>;
+
+export const SendMessageResponseSchema = SuccessEnvelope(
+  Type.Object({ message: MessagePublicSchema }),
+);
+export type SendMessageResponse = Static<typeof SendMessageResponseSchema>;
+
+export const EditMessageRequestSchema = Type.Object(
+  {
+    bodyText: Type.String({ minLength: 1, maxLength: MESSAGE_BODY_MAX_LENGTH }),
+  },
+  { additionalProperties: false },
+);
+export type EditMessageRequest = Static<typeof EditMessageRequestSchema>;
+
+export const EditMessageResponseSchema = SuccessEnvelope(
+  Type.Object({ message: MessagePublicSchema }),
+);
+export type EditMessageResponse = Static<typeof EditMessageResponseSchema>;
+
+export const DeleteMessageResponseSchema = SuccessEnvelope(Type.Object({ ok: Type.Literal(true) }));
+export type DeleteMessageResponse = Static<typeof DeleteMessageResponseSchema>;
+
+export const ListMessagesQuerySchema = Type.Object(
+  {
+    beforeSequence: Type.Optional(Type.Integer({ minimum: 1 })),
+    afterSequence: Type.Optional(Type.Integer({ minimum: 0 })),
+    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+  },
+  { additionalProperties: false },
+);
+export type ListMessagesQuery = Static<typeof ListMessagesQuerySchema>;
+
+export const ListMessagesResponseSchema = SuccessEnvelope(
+  Type.Object({
+    chatId: Type.String({ format: 'uuid' }),
+    headSequence: Type.Integer({ minimum: 0 }),
+    messages: Type.Array(MessagePublicSchema),
+  }),
+);
+export type ListMessagesResponse = Static<typeof ListMessagesResponseSchema>;
+
+export const SendDirectMessageRequestSchema = SendMessageRequestSchema;
+export type SendDirectMessageRequest = Static<typeof SendDirectMessageRequestSchema>;
+
+export const SendDirectMessageResponseSchema = SuccessEnvelope(
+  Type.Object({
+    chat: Type.Object({
+      id: Type.String({ format: 'uuid' }),
+      created: Type.Boolean(),
+    }),
+    message: MessagePublicSchema,
+  }),
+);
+export type SendDirectMessageResponse = Static<typeof SendDirectMessageResponseSchema>;
+
+export const AdvanceReadStateRequestSchema = Type.Object(
+  {
+    readUpToSequence: Type.Integer({ minimum: 0 }),
+  },
+  { additionalProperties: false },
+);
+export type AdvanceReadStateRequest = Static<typeof AdvanceReadStateRequestSchema>;
+
+export const AdvanceReadStateResponseSchema = SuccessEnvelope(
+  Type.Object({
+    chatId: Type.String({ format: 'uuid' }),
+    lastReadSequence: Type.Integer({ minimum: 0 }),
+  }),
+);
+export type AdvanceReadStateResponse = Static<typeof AdvanceReadStateResponseSchema>;
+
+export const ReadStateResponseSchema = SuccessEnvelope(
+  Type.Object({
+    chatId: Type.String({ format: 'uuid' }),
+    lastReadSequence: Type.Integer({ minimum: 0 }),
+    headSequence: Type.Integer({ minimum: 0 }),
+    hasUnread: Type.Boolean(),
+  }),
+);
+export type ReadStateResponse = Static<typeof ReadStateResponseSchema>;

--- a/packages/shared-schemas/src/schemas/test-seed.ts
+++ b/packages/shared-schemas/src/schemas/test-seed.ts
@@ -19,6 +19,16 @@ const MembershipSeedSchema = Type.Object({
   role: Type.Union([Type.Literal('member'), Type.Literal('moderator'), Type.Literal('owner')]),
 });
 
+// Distinct from `memberships` because it identifies the room by its
+// `chat_id` (returned from `POST /rooms`) rather than by name. The two
+// shapes are not merged so a spec author can't accidentally reference a
+// non-existent room name and have it silently no-op.
+const RoomMembershipByChatIdSeedSchema = Type.Object({
+  chatId: Type.String({ format: 'uuid' }),
+  username: Type.String(),
+  role: Type.Union([Type.Literal('member'), Type.Literal('admin'), Type.Literal('owner')]),
+});
+
 const FriendshipSeedSchema = Type.Object({
   userA: Type.String(),
   userB: Type.String(),
@@ -41,10 +51,21 @@ const MessageSeedSchema = Type.Object({
 });
 
 export const TestSeedRequestSchema = Type.Object({
-  strategy: Type.Optional(Type.Union([Type.Literal('truncate'), Type.Literal('upsert')])),
+  strategy: Type.Optional(
+    Type.Union([
+      Type.Literal('truncate'),
+      Type.Literal('upsert'),
+      // 'append' runs no TRUNCATE and inserts the supplied fixture rows
+      // with ON CONFLICT DO NOTHING. Used by specs that need to add
+      // room memberships or friendships after an earlier /__test/seed
+      // truncate + subsequent HTTP-level setup (e.g., room create).
+      Type.Literal('append'),
+    ]),
+  ),
   users: Type.Optional(Type.Array(UserSeedSchema)),
   rooms: Type.Optional(Type.Array(RoomSeedSchema)),
   memberships: Type.Optional(Type.Array(MembershipSeedSchema)),
+  roomMembershipsByChatId: Type.Optional(Type.Array(RoomMembershipByChatIdSeedSchema)),
   friendships: Type.Optional(Type.Array(FriendshipSeedSchema)),
   blocks: Type.Optional(Type.Array(BlockSeedSchema)),
   messages: Type.Optional(Type.Array(MessageSeedSchema)),


### PR DESCRIPTION
## Summary

Lands the WS-04 durable-history + read-state HTTP layer: message send/edit/delete, history pagination, direct-message lazy creation, and explicit read-state advance. Provides the stable contract WS-05 will layer its realtime fan-out on top of.

## Testing

- Playwright specs under `e2e/specs/AC-MSG-*`, `AC-RT-03`, `AC-DM-04`, `AC-DM-05`, `AC-UNREAD-01..03` cover each delivered AC end-to-end through `/__test/seed` + HTTP.
- `pnpm typecheck`, `pnpm lint`, `pnpm doc-consistency`, `pnpm schema-drift` all clean locally.
- Unit smoke suite (`apps/api` vitest) green via pre-push.

## AC IDs addressed
- AC-MSG-01: Supported content forms (`e2e/specs/AC-MSG-01-content-forms.spec.ts`)
- AC-MSG-02: 3 KB size limit (`e2e/specs/AC-MSG-02-size-limit.spec.ts`)
- AC-MSG-03: Stable chronological ordering (`e2e/specs/AC-MSG-03-ordering.spec.ts`)
- AC-MSG-04: Author edits own message (`e2e/specs/AC-MSG-04-edit-own.spec.ts`)
- AC-MSG-05: Admin deletes room message (`e2e/specs/AC-MSG-05-admin-delete.spec.ts`)
- AC-MSG-06: DM delete restricted to author (`e2e/specs/AC-MSG-06-dm-delete-restricted.spec.ts`)
- AC-MSG-07: Offline → miss → catch up via history (`e2e/specs/AC-MSG-07-offline-catchup.spec.ts`)
- AC-MSG-08: Infinite scroll via beforeSequence (`e2e/specs/AC-MSG-08-infinite-scroll.spec.ts`)
- AC-RT-03: Chat-local sequence allocation (`e2e/specs/AC-RT-03-sequence-allocation.spec.ts`)
- AC-DM-04: DM requires friendship + no block (`e2e/specs/AC-DM-04-dm-eligibility.spec.ts`)
- AC-DM-05: First DM creates direct chat (`e2e/specs/AC-DM-05-first-dm.spec.ts`)
- AC-UNREAD-01: Room unread indicator (`e2e/specs/AC-UNREAD-01-room-indicator.spec.ts`)
- AC-UNREAD-02: DM unread indicator (`e2e/specs/AC-UNREAD-02-dm-indicator.spec.ts`)
- AC-UNREAD-03: Explicit read-state advance (`e2e/specs/AC-UNREAD-03-explicit-advance.spec.ts`)

Deferred within WS-04: AC-UNREAD-04 (needs WS-05 ws fan-out), AC-RT-04 gap-repair `sync.request/response` (WS-05), and the `message.*` / `readstate.updated` event emissions (WS-05).

## Docs updated
- `docs/traceability.md` — WS-04 autorun status notes for every delivered AC, and the stale "POST /dm/{userId}/messages not yet documented" note is rewritten now that the endpoint has landed.
- `docs/workstream-notes/ws-04-progress.md` — delivery plan + contracts handed to WS-05/06/07.
- `docs/data-model.md` — no changes required. Migration `0004_ws04_messaging.sql` creates the `messages` and `chat_read_state` tables exactly as §4.13 and §4.16 already spec them (bigint `sequence`, `(chat_id, sequence)` unique, `kind` enum, reply FK, nullable edit/delete timestamps; composite-PK `(chat_id, user_id)` for read-state with `last_read_sequence bigint NOT NULL DEFAULT 0`). No columns, enum values, or indexes diverge from the existing doc.

## Destructive-migration disclosure
None. Migration `0004_ws04_messaging.sql` only adds the `messages` and `chat_read_state` tables with their indexes — no `DROP`, no `ALTER ... NOT NULL` on existing columns, no renames.

## Dependencies added
None. Uses existing Drizzle, TypeBox, postgres-js, Fastify packages already declared by WS-01/02/03.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent messaging with per-chat sequencing, threading (replies), edits, soft-deletes, and per-user read-state; direct messages with friendship/block eligibility and lazy DM chat creation; 3 KB UTF‑8 message size validation

* **APIs**
  * Endpoints to send/list/edit/delete messages and to advance/fetch read state; test-only direct-chat count inspector

* **Database**
  * Migration adding messages and chat-read-state tables with constraints and indexes

* **Tests**
  * Extensive Playwright E2E suites covering messaging, DMs, ordering, pagination, edits, deletes, and read-state

* **Documentation**
  * Updated messaging schemas, traceability, data-model, and workstream notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->