### PR TITLE
chore: enable CodeRabbit auto-review on draft PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,7 +15,7 @@ reviews:
   review_status: true
   auto_review:
     enabled: true
-    drafts: false
+    drafts: true
     base_branches:
       - main
       - develop


### PR DESCRIPTION
## Summary

Flips `.coderabbit.yaml` `auto_review.drafts` from `false` to `true` so autorun sessions' draft PRs get auto-reviewed. Previously CR posted "Review skipped — Draft detected" and required explicit `@coderabbitai review` to trigger a review on a draft, which broke the autonomy flow.

## Testing

None required — single-value config flip. Next autorun session's draft PR is the verification.

## AC IDs addressed

None — infrastructure/chore.

## Docs updated

None.

## Destructive-migration disclosure

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to enable automatic AI reviews for draft pull requests. Draft PRs will now receive automated code review feedback alongside regular pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->