### PR TITLE
AC-BOOT-00: /readyz endpoint + observability baseline (WS-08 autorun)

### DIFF
--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -8,12 +8,14 @@ import { attachmentsRoutes, attachmentsTestHelpers } from '../modules/attachment
 import { config } from '../config/env.js';
 import { realtimeGateway } from '../modules/realtime/index.js';
 import { healthzRoute } from './healthz.js';
+import { readyzRoute } from './readyz.js';
 import { testSeedRoute } from './test-seed.js';
 
 export const registerRoutes: FastifyPluginAsyncTypebox = async (fastify) => {
   await fastify.register(authPlugin);
   await fastify.register(realtimeGateway);
   await fastify.register(healthzRoute);
+  await fastify.register(readyzRoute);
   await fastify.register(testSeedRoute);
   await fastify.register(authRoutes);
   await fastify.register(roomsRoutes);

--- a/apps/api/src/routes/readyz.ts
+++ b/apps/api/src/routes/readyz.ts
@@ -1,0 +1,135 @@
+import type { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
+import { access, constants, readdir } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  ReadyzResponseSchema,
+  ErrorEnvelopeSchema,
+  ErrorCodes,
+} from 'shared-schemas';
+import { pgSql } from '../db/client.js';
+import { redis } from '../redis/client.js';
+import { config } from '../config/env.js';
+
+type CheckStatus = 'ok' | 'down';
+
+const packageJsonPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'package.json',
+);
+const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+  version: string;
+};
+
+const migrationsDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'drizzle',
+);
+
+// Resolve the expected migration count once at module load. Why cache: /readyz
+// is hit by orchestrators at poll-rate (every few seconds) and re-listing the
+// directory on every probe would be wasteful. The migration directory is
+// immutable for the lifetime of a running API container.
+let expectedMigrationCountPromise: Promise<number> | undefined;
+function expectedMigrationCount(): Promise<number> {
+  if (expectedMigrationCountPromise === undefined) {
+    expectedMigrationCountPromise = readdir(migrationsDir).then((entries) =>
+      entries.filter((f) => f.endsWith('.sql')).length,
+    );
+  }
+  return expectedMigrationCountPromise;
+}
+
+export function __resetMigrationCountCacheForTests(): void {
+  expectedMigrationCountPromise = undefined;
+}
+
+async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<T>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error('timeout'));
+    }, ms);
+  });
+  try {
+    return await Promise.race([p, timeoutPromise]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+export async function checkMigrationsApplied(): Promise<CheckStatus> {
+  const expected = await expectedMigrationCount();
+  const rows = await pgSql<{ count: number }[]>`
+    SELECT count(*)::int AS count FROM _migrations
+  `;
+  const applied = rows[0]?.count ?? 0;
+  return applied >= expected && expected > 0 ? 'ok' : 'down';
+}
+
+export const readyzRoute: FastifyPluginAsyncTypebox = (fastify) => {
+  fastify.get(
+    '/readyz',
+    {
+      schema: {
+        response: {
+          200: ReadyzResponseSchema,
+          503: ErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      const checks: {
+        db: CheckStatus;
+        redis: CheckStatus;
+        attachments: CheckStatus;
+        migrations: CheckStatus;
+      } = { db: 'down', redis: 'down', attachments: 'down', migrations: 'down' };
+
+      const [dbResult, redisResult, fsResult, migrationsResult] =
+        await Promise.allSettled([
+          withTimeout(pgSql`SELECT 1`, 250),
+          withTimeout(redis.ping(), 250),
+          withTimeout(access(config.ATTACHMENT_ROOT_DIR, constants.W_OK), 250),
+          withTimeout(checkMigrationsApplied(), 500),
+        ]);
+
+      checks.db = dbResult.status === 'fulfilled' ? 'ok' : 'down';
+      checks.redis = redisResult.status === 'fulfilled' ? 'ok' : 'down';
+      checks.attachments = fsResult.status === 'fulfilled' ? 'ok' : 'down';
+      checks.migrations =
+        migrationsResult.status === 'fulfilled' ? migrationsResult.value : 'down';
+
+      const failing = (
+        Object.entries(checks) as [keyof typeof checks, CheckStatus][]
+      )
+        .filter(([, v]) => v !== 'ok')
+        .map(([k]) => k);
+
+      if (failing.length > 0) {
+        return reply.status(503).send({
+          error: {
+            code: ErrorCodes.SERVICE_UNAVAILABLE,
+            message: 'One or more readiness checks failed.',
+            details: { failing, checks },
+            traceId: reply.request.id,
+          },
+        });
+      }
+
+      return reply.status(200).send({
+        data: {
+          status: 'ready',
+          checks,
+          version: pkg.version,
+        },
+      });
+    },
+  );
+  return Promise.resolve();
+};

--- a/apps/api/test/unit/routes/readyz.test.ts
+++ b/apps/api/test/unit/routes/readyz.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import Fastify from 'fastify';
+import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+import sensible from '@fastify/sensible';
+import type * as FsPromisesModule from 'node:fs/promises';
+
+// Mutable holders so each test can rewire the mocked behavior without
+// re-hoisting a fresh `vi.mock` call. The factory below reads these
+// closures at request time.
+const mocks = {
+  migrationsRows: [] as { count: number }[],
+  redisPing: (): Promise<'PONG'> => Promise.resolve('PONG'),
+  fsAccess: (): Promise<void> => Promise.resolve(),
+  readdirEntries: ['0001_initial.sql', '0002_auth.sql'],
+};
+
+vi.mock('../../../src/db/client.js', () => ({
+  pgSql: Object.assign(
+    // pgSql`SELECT 1` tag-call: resolves to any non-empty array (the route
+    // only cares that it resolves, not the payload shape). pgSql`SELECT count…`
+    // needs to return the migrations-row payload. We distinguish on the SQL
+    // template's first string fragment.
+    (strings: TemplateStringsArray) => {
+      const sql = strings.join(' ');
+      if (/count\(\*\)/.test(sql)) {
+        return Promise.resolve(mocks.migrationsRows);
+      }
+      return Promise.resolve([{ ok: 1 }]);
+    },
+    {
+      unsafe: () => ({ simple: () => Promise.resolve(undefined) }),
+    },
+  ),
+}));
+
+vi.mock('../../../src/redis/client.js', () => ({
+  redis: {
+    ping: (): Promise<'PONG'> => mocks.redisPing(),
+  },
+}));
+
+vi.mock('node:fs/promises', async () => {
+  const actual =
+    await vi.importActual<typeof FsPromisesModule>('node:fs/promises');
+  return {
+    ...actual,
+    access: (): Promise<void> => mocks.fsAccess(),
+    readdir: (): Promise<string[]> => Promise.resolve(mocks.readdirEntries),
+  };
+});
+
+vi.mock('../../../src/config/env.js', () => ({
+  config: {
+    ATTACHMENT_ROOT_DIR: '/tmp/attachments-readyz-test',
+    DATABASE_URL: 'postgres://stub',
+  },
+}));
+
+async function buildApp() {
+  const { readyzRoute, __resetMigrationCountCacheForTests } = await import(
+    '../../../src/routes/readyz.js'
+  );
+  __resetMigrationCountCacheForTests();
+  const app = Fastify().withTypeProvider<TypeBoxTypeProvider>();
+  await app.register(sensible);
+  await app.register(readyzRoute);
+  return app;
+}
+
+describe('GET /readyz', () => {
+  beforeEach(() => {
+    mocks.migrationsRows = [{ count: 2 }];
+    mocks.redisPing = () => Promise.resolve('PONG');
+    mocks.fsAccess = () => Promise.resolve();
+    mocks.readdirEntries = ['0001_initial.sql', '0002_auth.sql'];
+  });
+
+  test('returns 200 with status=ready when every dependency is healthy', async () => {
+    const app = await buildApp();
+    try {
+      const res = await app.inject({ method: 'GET', url: '/readyz' });
+      expect(res.statusCode).toBe(200);
+      const body: {
+        data: {
+          status: string;
+          checks: {
+            db: string;
+            redis: string;
+            attachments: string;
+            migrations: string;
+          };
+        };
+      } = res.json();
+      expect(body.data.status).toBe('ready');
+      expect(body.data.checks).toEqual({
+        db: 'ok',
+        redis: 'ok',
+        attachments: 'ok',
+        migrations: 'ok',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('returns 503 with migrations=down when _migrations count is below the expected file count', async () => {
+    mocks.migrationsRows = [{ count: 1 }];
+    mocks.readdirEntries = ['0001_initial.sql', '0002_auth.sql'];
+    const app = await buildApp();
+    try {
+      const res = await app.inject({ method: 'GET', url: '/readyz' });
+      expect(res.statusCode).toBe(503);
+      const body: {
+        error: {
+          code: string;
+          details?: {
+            failing?: string[];
+            checks?: { migrations?: string };
+          };
+        };
+      } = res.json();
+      expect(body.error.code).toBe('SERVICE_UNAVAILABLE');
+      expect(body.error.details?.checks?.migrations).toBe('down');
+      expect(body.error.details?.failing).toContain('migrations');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('returns 503 when redis is unreachable but reports other checks faithfully', async () => {
+    mocks.redisPing = () => Promise.reject(new Error('ECONNREFUSED'));
+    const app = await buildApp();
+    try {
+      const res = await app.inject({ method: 'GET', url: '/readyz' });
+      expect(res.statusCode).toBe(503);
+      const body: {
+        error: {
+          details?: { failing?: string[]; checks?: Record<string, string> };
+        };
+      } = res.json();
+      expect(body.error.details?.failing).toEqual(['redis']);
+      expect(body.error.details?.checks?.db).toBe('ok');
+      expect(body.error.details?.checks?.migrations).toBe('ok');
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/docs/api-and-events.md
+++ b/docs/api-and-events.md
@@ -1219,7 +1219,7 @@ Per §5.0, the ready body is wrapped: `{ "data": { "status": "ready", ... } }`. 
 - not rate-limited (hit at probe frequency)
 - check semantics:
   - `db`, `redis`, `attachments`: identical to `/healthz` (same 250ms timeout)
-  - `migrations`: the `_migrations` bookkeeping table contains at least as many rows as there are `*.sql` files under `apps/api/drizzle/`; computed with a 500ms timeout
+  - `migrations`: the `_migrations` bookkeeping table contains at least as many rows as there are `*.sql` files under `apps/api/drizzle/`, and the expected count is non-zero (so an empty `apps/api/drizzle/` on disk reports `migrations: 'down'` rather than a vacuous `'ok'`); computed with a 500ms timeout
 - if any check fails → 503 with `error.code = "SERVICE_UNAVAILABLE"`; `details.failing` lists the failing check names
 - the expected migration count is resolved lazily on the first `/readyz` call and cached for the life of the process — the migrations directory is immutable for a running container
 

--- a/docs/api-and-events.md
+++ b/docs/api-and-events.md
@@ -1108,6 +1108,8 @@ Recommended convenience endpoint to hydrate app shell after page load.
 
 ## 5.10 Health and operations
 
+The API exposes two unauthenticated probe endpoints. `/healthz` is the liveness-style probe used by `compose.yaml` to gate `depends_on: service_healthy`; `/readyz` is the readiness-style probe that additionally asserts schema migrations have run. See `docs/observability.md` §3 for the semantic distinction.
+
 ### GET `/healthz`
 
 Un-authenticated liveness + readiness probe. Used by Docker healthchecks and CI service-container waits.
@@ -1164,6 +1166,64 @@ Per §5.0, the happy response body is wrapped: `{ "data": { "status": "ok", ... 
 - `version` is read from `package.json` at startup; do not call it per-request
 
 Linked to AC-BOOT-00.
+
+### GET `/readyz`
+
+Un-authenticated readiness probe. Distinct from `/healthz`: returns ready only when the process can serve request traffic *right now*, including having its schema migrations applied. Used by Kubernetes-style readinessProbe callers and by future rolling-deploy orchestrators.
+
+#### Response (ready)
+
+HTTP 200:
+
+```json
+{
+  "status": "ready",
+  "checks": {
+    "db": "ok",
+    "redis": "ok",
+    "attachments": "ok",
+    "migrations": "ok"
+  },
+  "version": "0.1.0"
+}
+```
+
+#### Response (not ready)
+
+HTTP 503:
+
+```json
+{
+  "error": {
+    "code": "SERVICE_UNAVAILABLE",
+    "message": "One or more readiness checks failed.",
+    "details": {
+      "failing": ["migrations"],
+      "checks": {
+        "db": "ok",
+        "redis": "ok",
+        "attachments": "ok",
+        "migrations": "down"
+      }
+    },
+    "traceId": "..."
+  }
+}
+```
+
+Per §5.0, the ready body is wrapped: `{ "data": { "status": "ready", ... } }`. The not-ready body is wrapped as an `error` envelope.
+
+#### Rules
+
+- no authentication required; no CSRF enforcement
+- not rate-limited (hit at probe frequency)
+- check semantics:
+  - `db`, `redis`, `attachments`: identical to `/healthz` (same 250ms timeout)
+  - `migrations`: the `_migrations` bookkeeping table contains at least as many rows as there are `*.sql` files under `apps/api/drizzle/`; computed with a 500ms timeout
+- if any check fails → 503 with `error.code = "SERVICE_UNAVAILABLE"`; `details.failing` lists the failing check names
+- the expected migration count is resolved once at module load and cached for the life of the process — the migrations directory is immutable for a running container
+
+Linked to AC-BOOT-00. Rationale for the liveness/readiness split: `docs/observability.md` §3.
 
 ## 6. WebSocket contract
 

--- a/docs/api-and-events.md
+++ b/docs/api-and-events.md
@@ -1112,7 +1112,7 @@ The API exposes two unauthenticated probe endpoints. `/healthz` is the liveness-
 
 ### GET `/healthz`
 
-Un-authenticated liveness + readiness probe. Used by Docker healthchecks and CI service-container waits.
+Un-authenticated liveness probe. Used by Docker healthchecks and CI service-container waits; gates `compose.yaml`'s `depends_on: service_healthy`. Runs the dependency sub-checks below so compose can hold startup until Postgres/Redis/the attachment volume are reachable — but does NOT include the migrations-applied gate, which is what distinguishes `/readyz` (see §5.10 just below).
 
 #### Response (healthy)
 
@@ -1221,7 +1221,7 @@ Per §5.0, the ready body is wrapped: `{ "data": { "status": "ready", ... } }`. 
   - `db`, `redis`, `attachments`: identical to `/healthz` (same 250ms timeout)
   - `migrations`: the `_migrations` bookkeeping table contains at least as many rows as there are `*.sql` files under `apps/api/drizzle/`; computed with a 500ms timeout
 - if any check fails → 503 with `error.code = "SERVICE_UNAVAILABLE"`; `details.failing` lists the failing check names
-- the expected migration count is resolved once at module load and cached for the life of the process — the migrations directory is immutable for a running container
+- the expected migration count is resolved lazily on the first `/readyz` call and cached for the life of the process — the migrations directory is immutable for a running container
 
 Linked to AC-BOOT-00. Rationale for the liveness/readiness split: `docs/observability.md` §3.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,178 @@
+# Observability
+## Online Chat Server
+
+## 1. Purpose
+
+This doc is the baseline for "how do I see what the running API is
+doing". It covers what is implemented today (logging, request IDs,
+health + readiness probes) and the near-term plan for metrics and
+tracing.
+
+Observability is owned by WS-08 (see
+`docs/workstreams/proposed-workstreams.md` — the workstream's
+deliverable list includes "structured logs and metrics wiring",
+"health checks and readiness checks", and "diagnostic logging
+baseline"). New observability surface — an endpoint, a log field, a
+metric — lands here so operators and future maintainers have one
+place to look.
+
+## 2. Logging
+
+### 2.1 Library and level
+
+Pino (`pino`) is the single logger. It is configured in
+`apps/api/src/logger.ts`. Log level is read from `LOG_LEVEL` (env
+var), defaulting per `docs/runtime-and-environment.md`.
+
+- Under `NODE_ENV=development` the logger uses `pino-pretty` transport
+  for human-friendly stdout.
+- Under `NODE_ENV=test` / `production` the logger emits compact JSON
+  on stdout. A container runtime (compose, ECS, Kubernetes) is
+  expected to forward stdout to the centralised log sink.
+
+### 2.2 No `console.*`
+
+`console.log` / `console.error` / friends are banned in
+`apps/api/src/**` (ESLint `no-console: error` + Claude Code Write
+hook — see `docs/ai-development-guardrails.md` §5.1). Use
+`req.log` (a child logger that already carries `reqId`) inside
+request handlers, or `logger` (the module-level export) in
+bootstrap code.
+
+### 2.3 Request IDs
+
+Every HTTP request is assigned a UUIDv4 `reqId` at the Fastify layer
+(`genReqId` in `apps/api/src/server.ts`). The id:
+
+- is attached to every log line Fastify emits for that request;
+- is surfaced to clients as `error.traceId` in the error envelope
+  (see `docs/error-envelope-and-conventions.md` and `api-and-events.md`
+  §5.0);
+- may be propagated into WebSocket event metadata in a future step —
+  not yet wired.
+
+When troubleshooting a failing request, the `traceId` returned in the
+HTTP error envelope is the canonical log key — `grep` for it against
+the pod's stdout.
+
+### 2.4 What is logged at what level
+
+The project does not hand-write per-endpoint request/response logs —
+Fastify's built-in request logger (`disableRequestLogging: false`)
+handles the request/response pair at `info`. Error-handler code paths
+promote 5xx to `error` in `apps/api/src/server.ts`; 4xx domain denials
+stay silent to keep the log signal clean.
+
+Ad-hoc `req.log.debug` calls are allowed in service code, but prefer
+structured fields (`req.log.info({ room: roomId }, 'room created')`)
+over format-string interpolation so downstream log tooling can filter
+by field.
+
+## 3. Health and readiness probes
+
+The API exposes two unauthenticated probe endpoints. They are the
+seam between the process and the orchestrator (Docker Compose today,
+Kubernetes-style liveness/readiness in the future).
+
+| Endpoint    | Semantics                     | Used by                   |
+| ----------- | ----------------------------- | ------------------------- |
+| `GET /healthz` | Is the process up and can it reach its managed dependencies? | `compose.yaml` `healthcheck` — blocks `depends_on: service_healthy` |
+| `GET /readyz`  | Is the process ready to serve request traffic right now?     | Future K8s readinessProbe; today: documentation + smoke coverage     |
+
+Both endpoints:
+
+- require no authentication and are not CSRF-protected;
+- are not rate-limited (they are hit at probe frequency);
+- return `200` with a `data`-wrapped success envelope when everything
+  checks out, or `503` with an error envelope whose `error.code` is
+  `SERVICE_UNAVAILABLE` and whose `error.details.failing` lists the
+  check names that failed.
+
+The full wire contracts live in `docs/api-and-events.md` §5.10. The
+rest of this section explains the semantic distinction so a future
+contributor knows where to add a new check.
+
+### 3.1 What `/healthz` checks
+
+- `db`: `SELECT 1` against PostgreSQL (250 ms timeout).
+- `redis`: `PING` expecting `PONG` (250 ms timeout).
+- `attachments`: `ATTACHMENT_ROOT_DIR` is reachable and writable
+  (250 ms timeout).
+
+If any of these fail, the process is treated as liveness-compromised
+and compose's `depends_on.service_healthy` holds until they recover.
+The version string comes from `apps/api/package.json`, read once at
+startup.
+
+### 3.2 What `/readyz` checks
+
+Everything `/healthz` checks, plus:
+
+- `migrations`: the number of rows in the `_migrations` bookkeeping
+  table is at least the number of `*.sql` files shipped under
+  `apps/api/drizzle/`. This prevents a newly-booted pod whose
+  migrations never ran from being added to a load balancer.
+
+`/readyz` is the probe a rolling-deploy orchestrator should call to
+decide when a new replica is eligible for traffic. `/healthz` is the
+probe it should call to decide whether to restart a replica that has
+been running for a while but is no longer responsive. The split means
+a Redis blip restarts the API pod (which might fix a stuck client)
+rather than taking it out of rotation (which wouldn't help).
+
+For the MVP we expose both; compose continues to use `/healthz` so
+the existing `depends_on` wiring is unchanged.
+
+### 3.3 Adding a new check
+
+1. Decide: is the new dependency "needed for this process to be
+   alive" (→ add to `/healthz`) or "needed for the process to serve
+   request traffic right now" (→ add to `/readyz`)?
+2. Add the TypeBox status field to the matching schema
+   (`packages/shared-schemas/src/schemas/healthz.ts` or
+   `readyz.ts`).
+3. Add the probe to `apps/api/src/routes/healthz.ts` or
+   `readyz.ts`. Use `withTimeout` — every check must fail fast, since
+   the probe endpoint itself is hit at high frequency.
+4. Add a row to the table in `api-and-events.md` §5.10.
+5. Document the semantic in this file's §3.1 or §3.2.
+
+## 4. Metrics (planned)
+
+No `/metrics` endpoint is served today. When it lands, it will:
+
+- be registered here;
+- follow the Prometheus text exposition format;
+- expose at minimum: HTTP request counts + latency histogram by route
+  and status class, WebSocket event counts by type, database query
+  latency histogram, attachment-storage bytes written.
+
+Until then, log-based counting is the recommended fallback: every
+Fastify request emits a JSON line with `res.statusCode` and
+`responseTime`, and a log aggregator can derive counters from it.
+
+## 5. Tracing (planned)
+
+OpenTelemetry is not wired today. When it lands, the existing
+`reqId` will become the trace ID so retrospective correlation between
+pre-OTel logs and post-OTel traces is possible.
+
+## 6. Local operations cheat sheet
+
+- **Tail API logs (pretty)** — `docker compose logs -f api`.
+- **Probe liveness** — `curl -fsS http://localhost:3000/healthz | jq`.
+- **Probe readiness** — `curl -fsS http://localhost:3000/readyz | jq`.
+  A non-200 response indicates the API is not accepting traffic; read
+  `error.details.failing` for the short list.
+- **Find log lines for a failed request** — copy the `traceId` value
+  out of the error response and `grep` it in the API log stream.
+
+## 7. Related docs
+
+- `docs/runtime-and-environment.md` — env vars, compose, local boot.
+- `docs/api-and-events.md` §5.10 — wire contracts for `/healthz` and
+  `/readyz`.
+- `docs/error-envelope-and-conventions.md` — `traceId` field and
+  envelope shape.
+- `docs/ai-development-guardrails.md` §5.1 — `no-console` rule.
+- `docs/workstreams/proposed-workstreams.md` WS-08 — ownership.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,4 +1,5 @@
 # Observability
+
 ## Online Chat Server
 
 ## 1. Purpose

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -117,9 +117,18 @@ Everything `/healthz` checks, plus:
 `/readyz` is the probe a rolling-deploy orchestrator should call to
 decide when a new replica is eligible for traffic. `/healthz` is the
 probe it should call to decide whether to restart a replica that has
-been running for a while but is no longer responsive. The split means
-a Redis blip restarts the API pod (which might fix a stuck client)
-rather than taking it out of rotation (which wouldn't help).
+been running for a while but is no longer responsive.
+
+In the MVP the two probes share the base `db` / `redis` /
+`attachments` sub-checks, so those dependencies failing will fail both
+probes — whether that triggers a restart, a removal from the load
+balancer, or both depends entirely on orchestrator policy, not on
+the API's own behavior. The real value of the split today is
+isolating the migration-gating check: `/readyz` fails when migrations
+haven't run, `/healthz` does not, so a partially-booted pod is
+correctly "not ready" without also looking "not alive". Splitting out
+additional concerns per-probe (e.g., moving Redis into `/readyz`
+only) is a follow-up if and when rolling deploys care about it.
 
 For the MVP we expose both; compose continues to use `/healthz` so
 the existing `depends_on` wiring is unchanged.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -35,7 +35,7 @@ This table is checked by CI (`docs/ci-pipeline.md` → `doc-consistency.yml`):
 
 | AC ID      | Capability                        | HTTP                                      | WS event | State transition | Entities                   | Permissions row | Playwright test                |
 | ---------- | --------------------------------- | ----------------------------------------- | -------- | ---------------- | -------------------------- | --------------- | ------------------------------ |
-| AC-BOOT-00 | Stage-0 scaffolding and bootstrap | `GET /healthz`, `POST /__test/seed` (dev) | —        | —                | — (no persistent entities) | —               | `AC-BOOT-00-bootstrap.spec.ts` |
+| AC-BOOT-00 | Stage-0 scaffolding and bootstrap | `GET /healthz`, `GET /readyz`, `POST /__test/seed` (dev) | —        | —                | — (no persistent entities) | —               | `AC-BOOT-00-bootstrap.spec.ts`, `AC-BOOT-00-readyz.spec.ts` |
 
 ## 3.2 Stage-1 tooling (meta safety net)
 
@@ -164,6 +164,11 @@ Implementation status (WS-08 autorun, 2026-04-19):
 
 - AC-BOOT-00 (developer-seed slice) — `pnpm --filter api db:seed` replaced the previous stub with a deterministic, idempotent developer fixture (`apps/api/src/db/seed.ts`). The seed writes four users, three rooms (two public + one private), the memberships / friendship / block rows that exercise WS-03's relationship rules, and three sample messages in `general`. Pure INSERT … ON CONFLICT DO NOTHING — no destructive SQL. The runtime refuses to run under `NODE_ENV=production`. `/__test/seed` now also implements `strategy: 'upsert'` (previously 501 with a WS-08 deferral marker), so Playwright fixtures can layer state onto an already-populated DB without re-hashing the Argon2id passwords. The existing `e2e/specs/AC-BOOT-00-bootstrap.spec.ts` still covers the bootstrap row of §3.1. No new Playwright spec: AC-BOOT-00 is the same end-to-end contract (healthz + `/__test/seed`) and this PR extended its supporting infrastructure, not the AC itself. Unit tests: `apps/api/test/unit/db/seed.test.ts` (seed invariants + production-refusal) and the upsert branch of `apps/api/test/unit/plugins/test-seed.test.ts`.
 - **Deferred** within WS-08 (tracked in `docs/workstream-notes/ws-08-progress.md`): cross-workstream integration specs (depend on upstream AC-RT-02/04, AC-PRES-01..04, AC-MOD-* still deferred), `/readyz` endpoint + `docs/observability.md`, 30-day attachment hard-purge job, metrics / counters surface.
+
+Implementation status (WS-08 autorun, 2026-04-20):
+
+- AC-BOOT-00 (readiness-probe slice) — `GET /readyz` added as a distinct endpoint from `/healthz`. It runs the same `db` / `redis` / `attachments` checks plus a `migrations` check that asserts the `_migrations` bookkeeping table has at least as many rows as the `apps/api/drizzle/*.sql` file count, so a pod that is reachable but hasn't run schema migrations is reported not-ready. `/healthz` remains unchanged so `compose.yaml`'s `depends_on: service_healthy` wiring is backward-compatible. TypeBox schema at `packages/shared-schemas/src/schemas/readyz.ts`; route at `apps/api/src/routes/readyz.ts`. New Playwright spec `e2e/specs/AC-BOOT-00-readyz.spec.ts` covers the compose-stack happy path; unit test `apps/api/test/unit/routes/readyz.test.ts` covers the migrations-down and redis-down failure branches against mocked deps. The wire contract is documented in `docs/api-and-events.md` §5.10; the liveness-vs-readiness rationale is in the new `docs/observability.md` (§3). Upstream blockers for the remaining deferred items in the list below are unchanged.
+- **Still deferred** within WS-08 (tracked in `docs/workstream-notes/ws-08-progress.md`): cross-workstream composite specs — "reconnect → gap repair" (now unblocked by AC-RT-02/04, pick up next), "upload → remove-from-room → lose-download-access" (now unblocked by AC-MOD-02, pick up next), "multi-tab → online/AFK/offline" (still blocked on AC-PRES-01..04); the 30-day attachment hard-purge job; a metrics / counters surface.
 
 ## 5. Presence
 

--- a/docs/workstream-notes/ws-08-progress.md
+++ b/docs/workstream-notes/ws-08-progress.md
@@ -1,111 +1,111 @@
-# WS-08 autorun progress — 2026-04-19
+# WS-08 autorun progress — 2026-04-20
 
-Branch: `feature/WS-08-autorun-20260419`
+Branch: `feature/WS-08-autorun-20260420`
 
-## Scope decision
+## Prior WS-08 runs
 
-WS-08 (Integration, Seed Data, Observability, and Hardening) owns seed
-data + developer fixtures, cross-workstream E2E coverage, structured
-logging / metrics wiring, health/readiness probes, chaos/recovery
-scenarios, and the local developer workflow.
+- 2026-04-19 (#36, merged) — delivered the developer-seed slice of
+  AC-BOOT-00: real `pnpm --filter api db:seed`, `/__test/seed`
+  upsert strategy, seed unit tests, doc updates. That PR explicitly
+  deferred the following WS-08 items:
+  1. cross-workstream integration specs (blocked on upstream
+     AC-RT-02/04, AC-MOD-*, AC-PRES-01..04),
+  2. `/readyz` endpoint + `docs/observability.md`,
+  3. the 30-day attachment hard-purge job,
+  4. a metrics / counters surface.
 
-The full WS-08 surface is broad. Given the 80-turn autorun budget and
-the fact that several upstream ACs WS-08 would integration-test are
-still deferred (AC-RT-02/04 sync/reconnect, AC-PRES-01..04 multi-tab
-presence, AC-MOD-* moderation endpoints), this PR targets the **seed
-data + developer fixture** slice. It is the highest-leverage WS-08
-deliverable that is fully unblocked today and unblocks every downstream
-manual-testing and demo flow.
+Since then the upstream picture has changed:
+
+- AC-RT-02/04 (sync request/response + gap-repair rangeHint) landed in
+  `07cabf6` (#37).
+- AC-MOD-01..08 (room moderation HTTP surface) landed in `9e7c3db`
+  (#39).
+- AC-AUTH-05 / AC-AUTH-06 UI in `d2521b7` (#38).
+
+AC-PRES-01..04 and AC-AUTH-09 are still deferred upstream (WS-05 and
+WS-03 respectively).
+
+## Scope for this autorun
+
+This run targets the **observability baseline** slice. It is the
+highest-leverage WS-08 item that is fully unblocked today, and it is
+small enough to land cleanly in one autorun without touching other
+workstreams' code paths.
 
 ### In scope for this PR
 
-1. **Real `pnpm --filter api db:seed`** — replace the stub
-   (`echo "not yet implemented (WS-02)"`) with a deterministic dev seed.
-   The seed writes four fixture users (alice/bob/charlie/dana), two
-   public rooms, one private room, the membership rows that make alice
-   owner of each and bob admin of one, a friendship between alice and
-   bob, a block from charlie to dana, and a handful of sample messages
-   so the chat list is non-empty on first boot. Idempotent: safe to
-   re-run. Pure INSERT … ON CONFLICT DO NOTHING — no destructive SQL
-   (see `docs/ai-development-guardrails.md` §5.5).
-2. **`/__test/seed` upsert strategy** — the handler currently throws
-   501 on `strategy: 'upsert'` with a `WS-08` deferral comment. Landed
-   as a real upsert so repeated /__test/seed calls from a single
-   Playwright fixture can layer state without a full truncate. Scoped
-   to the same entity set the `truncate` strategy already handles
-   (users / friendships / blocks / room memberships), because extending
-   past that requires WS-03 HTTP surface that hasn't landed yet.
-3. **Unit tests for the seed entrypoint** — asserts the seed function
-   is pure-INSERT (no TRUNCATE / DROP) via module-import introspection
-   and asserts the upsert branch of `/__test/seed` is reachable under
-   `NODE_ENV=test`.
-4. **Docs** — `docs/runtime-and-environment.md` §8 updated to describe
-   what the seed produces so a first-time developer knows which
-   credentials work; `docs/testing-strategy.md` §4.3 updated to remove
-   the "upsert deferred" note.
+1. **New `GET /readyz` endpoint** — distinct from `/healthz`. Returns
+   503 with `error.code = SERVICE_UNAVAILABLE` if any of `db`, `redis`,
+   `attachments`, or the migrations-applied check fails. The
+   migrations check queries the Drizzle migrations table and asserts
+   that at least the current migration head is recorded, so a pod that
+   is reachable but hasn't run schema migrations is correctly reported
+   as not-ready. Response shape is carried by a new TypeBox schema
+   `ReadyzResponseSchema` in `packages/shared-schemas`.
+2. **`/healthz` unchanged** — compose's `healthcheck.test` hits
+   `/healthz` and `depends_on.service_healthy` is wired to it; the
+   semantic split (liveness = `/healthz`, readiness = `/readyz`) is
+   documented without breaking compose.
+3. **New doc `docs/observability.md`** — the observability baseline:
+   logger configuration, request-ID propagation, `/healthz` vs
+   `/readyz` semantics, and the near-term plan for metrics + tracing.
+   This is a new doc (not overlapping with any existing one — see
+   `docs/ai-development-guardrails.md` §10.2 allow-list for new docs).
+4. **`docs/api-and-events.md` §5.10** extended with the `/readyz`
+   endpoint spec (request/response/error envelope).
+5. **Playwright spec** `e2e/specs/AC-BOOT-00-readyz.spec.ts` — covers
+   the happy path (200 with `status: 'ready'`) against the running
+   compose stack. The `/healthz` case is still covered by the existing
+   `AC-BOOT-00-bootstrap.spec.ts`.
+6. **Unit test** for the migrations check so that a stubbed "no rows"
+   state correctly reports `migrations: 'down'` without requiring the
+   live DB to be broken.
+7. **Docs: `docs/traceability.md`** updated with a WS-08 2026-04-20
+   status block and the AC-BOOT-00 row extended to list `/readyz`.
 
-### Deferred within WS-08 (follow-up PRs)
+### Still deferred within WS-08 (follow-up PRs)
 
-- **Cross-workstream integration specs** — the test-ownership table
-  (`docs/workstreams/workstream-dependency-and-interface-map.md`)
-  assigns to WS-08: "send→unread→delivery", "reconnect→gap repair",
-  "upload→remove-from-room→lose access", "multi-tab→online/AFK/offline".
-  The first is partially covered by `AC-RT-01`; the next two depend on
-  AC-RT-02/04 and AC-MOD-02 which are still deferred upstream; the last
-  depends on AC-PRES-01..04 which is deferred in WS-05. A dedicated
-  WS-08 regression spec that composes the AC-level specs into a single
-  "developer smoke" path lands after the upstream pieces arrive.
-- **Readyz endpoint + observability baseline** — a new
-  `docs/observability.md` (planned, not yet committed) plus
-  `GET /readyz` are separable from the seed work and warrant their own
-  PR alongside a metrics surface decision. Current `GET /healthz`
-  already covers db / redis / attachments, so liveness is not broken.
-- **30-day attachment hard-purge job** — called out in
-  `docs/workstream-notes/ws-06-progress.md`; needs a scheduled-job
-  runner which is a separate scoping conversation.
-- **Metrics / counters** — Pino request logging is already enabled.
-  A structured metrics surface (Prometheus-text or /metrics JSON) is a
-  future WS-08 PR once we know what we need to instrument.
+- **Cross-workstream composite specs** — the test-ownership table in
+  `docs/workstreams/workstream-dependency-and-interface-map.md` assigns
+  these to WS-08:
+  - "send→unread→delivery" (partially covered by AC-RT-01/AC-UNREAD-01..04)
+  - "reconnect→gap repair" (now unblocked by AC-RT-02/04; pick up next)
+  - "upload→remove-from-room→lose-download-access" (now unblocked by
+    AC-MOD-02; pick up next)
+  - "multi-tab→online/AFK/offline transitions" (still blocked — waits
+    for AC-PRES-01..04 upstream)
+
+  These are held for their own PR because each one reads from multiple
+  test utilities and can noisily cross the 15-minute-review PR-size
+  threshold when bundled with the observability slice.
+
+- **30-day attachment hard-purge job** — needs a scheduled-job runner
+  decision (node-cron vs compose-level cron vs a lightweight timer
+  plugin). That scoping belongs to its own PR.
+
+- **Metrics / counters surface** — will follow observability.md with a
+  concrete Prometheus-text `/metrics` endpoint (or similar). Kept out
+  of this PR so the PR stays review-sized.
 
 ## Interfaces handed to other workstreams
 
-- **All streams**: `pnpm --filter api db:seed` is now a usable local
-  bootstrap step. The seeded credentials are documented in
-  `docs/runtime-and-environment.md` §8. Passwords are intentionally
-  well-known strings — the seed is dev-only and
-  `apps/api/src/db/seed.ts` refuses to run under `NODE_ENV=production`.
-- **WS-02 / WS-03 / WS-04 Playwright suites**: `/__test/seed` now
-  supports `strategy: 'upsert'` so a spec that only needs to *add* a
-  fixture user on top of an already-populated DB can do so without
-  truncating other specs' state. The existing `truncate` strategy
-  remains the Playwright default.
-
-## Final-phase status (end of autorun session)
-
-All code commits pushed on `feature/WS-08-autorun-20260419`:
-
-- `dd11616` — chore: progress note (opens draft PR)
-- `4a29b17` — AC-BOOT-00: real `pnpm db:seed`
-- `55e7a16` — AC-BOOT-00: upsert strategy + unit tests + docs
-- `69ba8c5` — fix: CodeRabbit round-1 (room-lookup normalisation, room race, message-dedup race)
-- `ed99d35` — fix: CodeRabbit round-2 (test normalization + mock-ordering comment)
-- `4dcf05d` — fix: target-less ON CONFLICT for username_canonical parity
-
-Seven CodeRabbit threads landed across the run; all have been addressed
-(via commit) and resolved via the GraphQL resolveReviewThread mutation.
-All CI jobs green on the final pushed commit (typecheck / lint / unit /
-integration / e2e-smoke / check-pr-title / check-pr-description /
-doc-consistency / schema-drift). CodeRabbit's final status is SUCCESS.
-PR marked ready and the cascade-ready marker comment was posted so the
-coordinator will pick it up.
+- **Operators / CI** — `GET /readyz` is available for compose and
+  future Kubernetes-style probes. `/healthz` is unchanged for backward
+  compat.
+- **Contributors** — `docs/observability.md` is the new single source
+  of truth for "how do I see what the running API is doing" (logs,
+  request IDs, health probes). No change to runtime config.
 
 ## Files likely touched
 
-- `apps/api/package.json` (db:seed script pointing at a real entrypoint)
-- `apps/api/src/db/seed.ts` (new)
-- `apps/api/src/routes/test-seed.ts` (upsert branch implementation)
-- `apps/api/test/unit/plugins/test-seed.test.ts` (upsert coverage)
-- `apps/api/test/unit/db/seed.test.ts` (new)
-- `docs/runtime-and-environment.md` (seed output description)
-- `docs/testing-strategy.md` (upsert strategy note updated)
-- `docs/traceability.md` (AC-BOOT-00 row status line)
+- `apps/api/src/routes/readyz.ts` (new)
+- `apps/api/src/routes/index.ts` (register)
+- `apps/api/test/unit/routes/readyz.test.ts` (new)
+- `packages/shared-schemas/src/schemas/readyz.ts` (new)
+- `packages/shared-schemas/src/index.ts` (export)
+- `docs/observability.md` (new)
+- `docs/api-and-events.md` (append §5.10)
+- `docs/traceability.md` (AC-BOOT-00 row + status block)
+- `e2e/specs/AC-BOOT-00-readyz.spec.ts` (new)
+
+No DB schema changes. No destructive SQL. No `zod`/`any`/etc.

--- a/docs/workstream-notes/ws-08-progress.md
+++ b/docs/workstream-notes/ws-08-progress.md
@@ -108,4 +108,4 @@ workstreams' code paths.
 - `docs/traceability.md` (AC-BOOT-00 row + status block)
 - `e2e/specs/AC-BOOT-00-readyz.spec.ts` (new)
 
-No DB schema changes. No destructive SQL. No `zod`/`any`/etc.
+No DB schema changes, no destructive SQL, and no `zod`/`any`/etc.

--- a/e2e/specs/AC-BOOT-00-readyz.spec.ts
+++ b/e2e/specs/AC-BOOT-00-readyz.spec.ts
@@ -1,15 +1,17 @@
 import { test, expect, request as apiRequest } from '@playwright/test';
 
+type CheckStatus = 'ok' | 'down';
+
 type ReadyzResponse = {
   data: {
-    status: string;
+    status: 'ready';
     checks: {
-      db: string;
-      redis: string;
-      attachments: string;
-      migrations: string;
+      db: CheckStatus;
+      redis: CheckStatus;
+      attachments: CheckStatus;
+      migrations: CheckStatus;
     };
-    version?: string;
+    version: string;
   };
 };
 
@@ -29,7 +31,7 @@ test('AC-BOOT-00 readyz: compose stack reports status=ready', async () => {
     expect(body.data.checks.redis).toBe('ok');
     expect(body.data.checks.attachments).toBe('ok');
     expect(body.data.checks.migrations).toBe('ok');
-    expect(typeof body.data.version).toBe('string');
+    expect(body.data.version.length).toBeGreaterThan(0);
   } finally {
     await api.dispose();
   }

--- a/e2e/specs/AC-BOOT-00-readyz.spec.ts
+++ b/e2e/specs/AC-BOOT-00-readyz.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+
+type ReadyzResponse = {
+  data: {
+    status: string;
+    checks: {
+      db: string;
+      redis: string;
+      attachments: string;
+      migrations: string;
+    };
+    version?: string;
+  };
+};
+
+// AC-BOOT-00 (readiness slice): /readyz reports `status: 'ready'` when
+// every dependency + the migrations bookkeeping check pass against a
+// fully-migrated compose stack. Distinct from /healthz — see
+// docs/observability.md §3. The /healthz happy-path is covered by
+// AC-BOOT-00-bootstrap.spec.ts.
+test('AC-BOOT-00 readyz: compose stack reports status=ready', async () => {
+  const api = await apiRequest.newContext({ baseURL: 'http://localhost:3000' });
+  try {
+    const res = await api.get('/readyz');
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as ReadyzResponse;
+    expect(body.data.status).toBe('ready');
+    expect(body.data.checks.db).toBe('ok');
+    expect(body.data.checks.redis).toBe('ok');
+    expect(body.data.checks.attachments).toBe('ok');
+    expect(body.data.checks.migrations).toBe('ok');
+    expect(typeof body.data.version).toBe('string');
+  } finally {
+    await api.dispose();
+  }
+});

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -1,5 +1,6 @@
 export * from './schemas/envelopes.js';
 export * from './schemas/healthz.js';
+export * from './schemas/readyz.js';
 export * from './schemas/test-seed.js';
 export * from './schemas/auth.js';
 export * from './schemas/rooms.js';

--- a/packages/shared-schemas/src/schemas/readyz.ts
+++ b/packages/shared-schemas/src/schemas/readyz.ts
@@ -1,0 +1,19 @@
+import { Type, type Static } from '@sinclair/typebox';
+import { SuccessEnvelope } from './envelopes.js';
+
+const CheckStatusSchema = Type.Union([Type.Literal('ok'), Type.Literal('down')]);
+
+export const ReadyzDataSchema = Type.Object({
+  status: Type.Literal('ready'),
+  checks: Type.Object({
+    db: CheckStatusSchema,
+    redis: CheckStatusSchema,
+    attachments: CheckStatusSchema,
+    migrations: CheckStatusSchema,
+  }),
+  version: Type.String(),
+});
+export type ReadyzData = Static<typeof ReadyzDataSchema>;
+
+export const ReadyzResponseSchema = SuccessEnvelope(ReadyzDataSchema);
+export type ReadyzResponse = Static<typeof ReadyzResponseSchema>;


### PR DESCRIPTION
## Summary

Lands the observability-baseline slice of WS-08 that was deferred by the prior WS-08 autorun (#36): adds a distinct `GET /readyz` readiness probe, introduces a first-class `docs/observability.md`, and extends `docs/api-and-events.md` §5.10 with the readiness contract. `/healthz` is left unchanged so compose's existing healthcheck stays green.

## Testing

- New Playwright spec `e2e/specs/AC-BOOT-00-readyz.spec.ts` covers the happy-path response against the compose stack.
- New unit test for the migrations-applied sub-check so a stubbed \"no rows\" state reports `migrations: 'down'` without requiring a broken live DB.
- Existing `AC-BOOT-00-bootstrap.spec.ts` continues to cover `/healthz`.

## AC IDs addressed

- AC-BOOT-00 — readiness probe slice (adds `GET /readyz` to the HTTP column; see `docs/traceability.md`).

## Docs updated

- `docs/observability.md` — new doc: logging baseline, request-id propagation, `/healthz` vs `/readyz`, near-term metrics/tracing plan.
- `docs/api-and-events.md` §5.10 — `/readyz` endpoint spec (response/error envelope).
- `docs/traceability.md` — AC-BOOT-00 row + WS-08 2026-04-20 status block.
- `docs/workstream-notes/ws-08-progress.md` — autorun progress note.

## Destructive-migration disclosure

None. No schema changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an unauthenticated readiness probe (GET /readyz) that checks DB, Redis, attachments, and migrations, returning 200 (ready) or 503 (SERVICE_UNAVAILABLE) with failing-check details and service version.

* **Documentation**
  * New observability guide; API docs updated to clarify liveness vs readiness, response envelopes, migrations caching/timeout semantics, and traceability now lists the probe.

* **Tests**
  * Added unit tests and an end-to-end spec covering success and failure scenarios.

* **Schemas**
  * Added shared readiness response schema for consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->