### PR TITLE
infra: add root README with docker compose quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,70 @@
+# Online Chat Server
+
+A self-contained, browser-based online chat application: public and private rooms,
+one-to-one direct messages, friend lists, persistent history, unread indicators,
+presence (online / AFK / offline), file and image attachments, active session
+management, and room moderation. Runs locally via Docker Compose. The full product
+scope is in [`docs/product-requirements.md`](docs/product-requirements.md).
+
+## Quickstart
+
+Prerequisites: [Docker](https://docs.docker.com/get-docker/) 24+ with Compose v2,
+and `openssl` (preinstalled on macOS and most Linux distros). The stack publishes
+host ports `3000` (API), `5173` (web), `5432` (postgres), `6379` (redis),
+`1025` / `8025` (Mailpit SMTP and UI) — keep them free.
+
+```bash
+git clone <repo-url>
+cd online-chat-server
+
+# 1. Create env files. The api container reads .env.local; Compose reads .env
+#    for ${VAR} interpolation.
+cp .env.example .env.local
+
+# 2. Replace the CHANGE_ME_32_BYTES placeholders with real 32-byte hex secrets.
+sed -i.bak "s|SESSION_SECRET=.*|SESSION_SECRET=$(openssl rand -hex 32)|" .env.local
+sed -i.bak "s|CSRF_SECRET=.*|CSRF_SECRET=$(openssl rand -hex 32)|" .env.local
+rm -f .env.local.bak
+cp .env.local .env
+
+# 3. Build and start the stack.
+docker compose up
+```
+
+Once `web` reports healthy, open <http://localhost:5173>.
+
+| Service | URL                                        |
+| ------- | ------------------------------------------ |
+| Web     | <http://localhost:5173>                    |
+| API     | <http://localhost:3000/healthz>            |
+| Mailpit | <http://localhost:8025> (captured outbound email) |
+
+> **Compose file naming**: Docker Compose v2 reads `compose.yaml` natively — it is
+> the modern equivalent of `docker-compose.yml`, and both filenames work with the
+> `docker compose up` command.
+
+### Shortcut
+
+If you have `pnpm` and `node` on the host, [`scripts/dev-bootstrap.sh`](scripts/dev-bootstrap.sh)
+does the env setup, runs `pnpm install`, brings the stack up with `--wait`, and
+polls `/healthz` in one command:
+
+```bash
+./scripts/dev-bootstrap.sh
+```
+
+## Tearing down
+
+```bash
+docker compose down -v
+```
+
+The `-v` flag removes the postgres, redis, and attachment volumes — use it when
+you want a clean slate.
+
+## Where to go next
+
+- [`docs/README.md`](docs/README.md) — full documentation index
+- [`docs/runtime-and-environment.md`](docs/runtime-and-environment.md) — services, env vars, troubleshooting
+- [`docs/repo-layout.md`](docs/repo-layout.md) — what lives where
+- [`CLAUDE.md`](CLAUDE.md) — rules for AI coding sessions on this repo


### PR DESCRIPTION
## Summary

QA reviewer (Alex, DataArt) cannot evaluate the project without a root `README.md` and clear instructions for the `docker compose up` flow. `compose.yaml` already orchestrates the full stack (postgres, redis, mailpit, api, web from their respective Dockerfiles) — the gap was purely documentation.

This PR adds a single root-level `README.md` (~70 lines) following the structure prescribed by `docs/repo-layout.md` §11:

- One-paragraph product description
- Literal `docker compose up` quickstart with the env-setup sequence a fresh clone needs (`cp .env.example .env.local`, replace `CHANGE_ME_32_BYTES` placeholders via `openssl rand -hex 32`, mirror to `.env` for compose variable substitution, then `docker compose up`)
- One-line note clarifying that `compose.yaml` is the modern equivalent of `docker-compose.yml` (addresses the QA's literal wording without a duplicate file)
- Service-URL table, shortcut to `scripts/dev-bootstrap.sh`, teardown command, links to `docs/`

No code, compose, Dockerfile, or env-example changes — only a new root README.

## AC IDs addressed

None directly required (`infra:` tag per `CLAUDE.md` §6 is sufficient). Related context: `AC-BOOT-00` (Stage-0 bootstrap) — this README documents the path that AC's Playwright smoke test exercises.

## Docs updated

- New file: `README.md` (root)
- No other doc changes — `docs/repo-layout.md` already lists the root README as planned and prescribes its shape; this PR fulfills that prescription.

## Testing

End-to-end verification (mirrors the QA's path):

1. Backed up existing `.env` / `.env.local`, deleted them to simulate a fresh-clone state.
2. Ran the README's literal commands verbatim (cp, sed, cp, `docker compose up -d --wait`).
3. All five services reported **Healthy**: `chat-postgres-1`, `chat-redis-1`, `chat-mailsink-1`, `chat-api-1`, `chat-web-1`.
4. `curl http://localhost:3000/healthz` → `{"data":{"status":"ok","checks":{"db":"ok","redis":"ok","attachments":"ok"},"version":"0.1.0"}}`
5. `curl http://localhost:5173` → Vite dev shell HTML
6. `curl http://localhost:8025/livez` → 200 (Mailpit)
7. `docker compose down -v` cleaned up; env backups restored.

Local checks:

- `pnpm doc-consistency` → **pass**
- `pnpm lint-compose` → fails on a pre-existing unrelated issue (`WEBSOCKET_PRESENCE_SCAN_INTERVAL_MS` not documented in `docs/runtime-and-environment.md` §6 — reproduces on `develop` without this change)
- Lefthook gates on push: `doc-consistency` ✔, `integration-smoke` ✔ (20/20 tests pass)
- Pre-commit: gitleaks ✔, ac-test-presence ✔ (skipped: infra branch), suppression-check ✔, no-ai-footer ✔, title-format ✔

## Screenshots

N/A (documentation only).

## Destructive-migration disclosure

None.

## Dependencies added

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README with quickstart guide, environment setup instructions, Docker prerequisites, build and startup commands, health check guidance, service endpoints, and teardown procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electronicostrich/online-chat-server/pull/54)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->